### PR TITLE
Fix/cicd build 129

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,10 +80,10 @@ jobs:
       - name: Check client generation summary
         run: |
           # Extract the number after "Failed: "
-          FAILED=$(grep -Eo "Failed: [0-9]+" build_clients.log | awk '{print $2}')
+          FAILED=$(grep -Eo "Failed: [0-9]+" build_clients.log | awk '{print $2}' | tail -n 1)
           if [ -z "$FAILED" ]; then
-            echo "Could not find 'Failed: N' in build_clients.log, all clients succeeded."
-            # Proceed even if not found, as output format might vary
+            echo "Could not find 'Failed: N' in build_clients.log; assuming 0 failures."
+            FAILED=0
           fi
           if [ "$FAILED" -gt 0 ]; then
             echo "Client generation summary check failed: Failed: $FAILED"

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -35,7 +35,7 @@ export default function Settings() {
     setIsSaving(true);
     setSaveStatus('idle');
     // Simulate API request
-    await new Promise(resolve => setTimeout(resolve, 800));
+    await new Promise((resolve) => setTimeout(resolve, 800));
     setIsSaving(false);
     setSaveStatus('success');
 
@@ -56,7 +56,9 @@ export default function Settings() {
     <div className="flex-1 flex flex-col items-center justify-start p-12 max-w-3xl mx-auto w-full">
       <div className="w-full mb-12 flex items-end justify-between border-b border-hi pb-8">
         <div>
-          <h1 className="text-4xl font-black mb-2 tracking-tight">{t('settings.title') || "Settings"}</h1>
+          <h1 className="text-4xl font-black mb-2 tracking-tight">
+            {t('settings.title') || 'Settings'}
+          </h1>
         </div>
       </div>
 
@@ -96,7 +98,9 @@ export default function Settings() {
                   >
                     Upload New Image
                   </button>
-                  <p className="text-xs text-muted mt-2">Recommended size: 256x256px. Max file size: 2MB.</p>
+                  <p className="text-xs text-muted mt-2">
+                    Recommended size: 256x256px. Max file size: 2MB.
+                  </p>
                 </div>
               </div>
             </div>
@@ -133,7 +137,9 @@ export default function Settings() {
                 <label className="block text-xs font-bold uppercase tracking-widest text-muted">
                   Preferred Stablecoin
                 </label>
-                <p className="text-xs text-muted mb-1">Default token used for payroll distributions.</p>
+                <p className="text-xs text-muted mb-1">
+                  Default token used for payroll distributions.
+                </p>
                 <select
                   value={stablecoin}
                   onChange={(e) => setStablecoin(e.target.value)}
@@ -169,7 +175,7 @@ export default function Settings() {
                 {isSaving ? (
                   <div className="w-5 h-5 border-2 border-black/20 border-t-black rounded-full animate-spin"></div>
                 ) : (
-                  "Save Changes"
+                  'Save Changes'
                 )}
               </button>
             </div>
@@ -180,16 +186,19 @@ export default function Settings() {
         <div className="w-full card glass noise p-8">
           <div className="flex flex-col gap-3">
             <label className="block text-xs font-bold uppercase tracking-widest text-muted">
-              {t('settings.languageLabel') || "Language"}
+              {t('settings.languageLabel') || 'Language'}
             </label>
-            <p className="text-sm text-muted">{t('settings.languageDescription') || "Choose your preferred user interface language."}</p>
+            <p className="text-sm text-muted">
+              {t('settings.languageDescription') ||
+                'Choose your preferred user interface language.'}
+            </p>
             <select
               value={i18n.language || 'en'}
               onChange={handleChangeLanguage}
               className="w-full bg-black/20 border border-hi rounded-xl p-4 text-text outline-none focus:border-accent/50 focus:bg-accent/5 transition-all mt-2"
             >
-              <option value="en">{t('settings.languageEnglish') || "English"}</option>
-              <option value="es">{t('settings.languageSpanish') || "Spanish"}</option>
+              <option value="en">{t('settings.languageEnglish') || 'English'}</option>
+              <option value="es">{t('settings.languageSpanish') || 'Spanish'}</option>
             </select>
           </div>
         </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -162,7 +162,7 @@ export default function Settings() {
                 Cancel
               </button>
               <button
-                onClick={handleSave}
+                onClick={() => void handleSave()}
                 className="px-6 py-2.5 rounded-xl font-bold bg-accent hover:bg-accent/80 text-black transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center min-w-[120px]"
                 disabled={isSaving}
               >

--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
       "eslint --fix --no-warn-ignored",
       "prettier --write --ignore-unknown"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Summary
Fix CI/CD pipeline build failures by:
1) Making the GitHub Actions client-generation summary check resilient to log format differences.
2) Fixing a frontend ESLint failure in [Settings.tsx](cci:7://file:///Users/mac/Documents/DripsOS/PayD/frontend/src/pages/Settings.tsx:0:0-0:0) caused by passing an async function directly to `onClick`.
3) Declaring the repo package manager for consistent tooling.

## Changes
### CI (GitHub Actions)
- Update [.github/workflows/build.yml](cci:7://file:///Users/mac/Documents/DripsOS/PayD/.github/workflows/build.yml:0:0-0:0) so the “Check client generation summary” step:
  - Uses the last matched `Failed: N` value when present
  - Defaults to `0` when the pattern is missing
  - Avoids bash numeric comparison errors on empty values

### Frontend (Lint)
- Update [frontend/src/pages/Settings.tsx](cci:7://file:///Users/mac/Documents/DripsOS/PayD/frontend/src/pages/Settings.tsx:0:0-0:0):
  - Replace `onClick={handleSave}` with `onClick={() => void handleSave()}` to satisfy `@typescript-eslint/no-misused-promises`

### Tooling
- Add `packageManager` field to [package.json](cci:7://file:///Users/mac/Documents/DripsOS/PayD/package.json:0:0-0:0) to make package manager choice explicit.

## How to verify
- GitHub Actions: run the `Build Project and Run Tests` workflow on this PR.
- Locally (optional):
  - `cd frontend && npm ci --legacy-peer-deps`
  - `npm run lint`

closes #100 