### PR TITLE
feat(sep-1): serve stellar.toml for ORGUSD

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,44 @@ app.use(cors());
 app.use(express.json());
 app.use(passport.initialize());
 
+app.get('/.well-known/stellar.toml', (req, res) => {
+  const issuer = process.env.ORGUSD_ISSUER_PUBLIC;
+  const networkPassphrase = process.env.STELLAR_NETWORK_PASSPHRASE;
+
+  if (!issuer) {
+    res.status(503).json({
+      error: 'Service Unavailable',
+      message: 'ORGUSD_ISSUER_PUBLIC is not configured',
+    });
+    return;
+  }
+
+  const toml = [
+    'VERSION="2.0.0"',
+    networkPassphrase ? `NETWORK_PASSPHRASE="${networkPassphrase}"` : null,
+    '',
+    '[DOCUMENTATION]',
+    'ORG_NAME="PayD"',
+    'ORG_URL="https://github.com/pope-h/PayD"',
+    'ORG_DESCRIPTION="PayD is a Stellar-based cross-border payroll platform."',
+    'ORG_GITHUB="pope-h/PayD"',
+    'ORG_OFFICIAL_EMAIL="support@example.com"',
+    '',
+    '[[CURRENCIES]]',
+    'code="ORGUSD"',
+    `issuer="${issuer}"`,
+    'display_decimals=2',
+    'name="ORGUSD"',
+    'desc="Organization-specific stablecoin used for payroll disbursements on Stellar."',
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n');
+
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.status(200).send(toml);
+});
+
 // Routes
 app.use('/auth', authRoutes);
 


### PR DESCRIPTION
## Summary
Implements SEP-0001 asset metadata hosting for the ORGUSD asset by serving a `stellar.toml` at `/.well-known/stellar.toml` from the backend, with CORS enabled for wallet/explorer discovery.

## Changes
- Add `GET /.well-known/stellar.toml` endpoint in [backend/src/index.ts](cci:7://file:///Users/mac/Documents/DripsOS/PayD/backend/src/index.ts:0:0-0:0)
  - Returns TOML content including:
    - `VERSION`
    - `NETWORK_PASSPHRASE` (when `STELLAR_NETWORK_PASSPHRASE` is set)
    - `[DOCUMENTATION]` org metadata + contact details
    - `[[CURRENCIES]]` entry for `ORGUSD` using `ORGUSD_ISSUER_PUBLIC`
  - Sets required headers:
    - `Access-Control-Allow-Origin: *`
    - `Content-Type: text/plain; charset=utf-8`

## Configuration
This endpoint requires:

- `ORGUSD_ISSUER_PUBLIC` (required)
- `STELLAR_NETWORK_PASSPHRASE` (optional but recommended)

If `ORGUSD_ISSUER_PUBLIC` is missing, the endpoint returns `503 Service Unavailable` with a clear error message.

## Validation
1. Run the backend with `ORGUSD_ISSUER_PUBLIC` set (from [backend/scripts/issue-orgusd.ts](cci:7://file:///Users/mac/Documents/DripsOS/PayD/backend/scripts/issue-orgusd.ts:0:0-0:0) output).
2. Visit:
   - `http://localhost:<PORT>/.well-known/stellar.toml`
3. Validate the result with:
   - Stellar Expert (domain/TOML discovery)
   - Any TOML/SEP-1 checker

Fixes #34