### PR TITLE
fix(bulk_payment): true partial-mode + overflow tests

### DIFF
--- a/contracts/bulk_payment/src/lib.rs
+++ b/contracts/bulk_payment/src/lib.rs
@@ -170,18 +170,28 @@ impl BulkPaymentContract {
             return Err(ContractError::BatchTooLarge);
         }
 
-        let mut total: i128 = 0;
+        let mut total_requested: i128 = 0;
         for op in payments.iter() {
             if op.amount > 0 {
-                total = total.checked_add(op.amount).ok_or(ContractError::AmountOverflow)?;
+                total_requested = total_requested
+                    .checked_add(op.amount)
+                    .ok_or(ContractError::AmountOverflow)?;
             }
         }
 
         let token_client = token::Client::new(&env, &token);
         let contract_addr = env.current_contract_address();
-        token_client.transfer(&sender, &contract_addr, &total);
 
-        let mut remaining = total;
+        // Pull only what the sender can actually cover. This makes the partial mode
+        // behave as a true best-effort batch rather than reverting on insufficient funds.
+        let sender_balance = token_client.balance(&sender);
+        let total_to_pull = core::cmp::min(total_requested, sender_balance);
+
+        if total_to_pull > 0 {
+            token_client.transfer(&sender, &contract_addr, &total_to_pull);
+        }
+
+        let mut remaining = total_to_pull;
         let mut success_count: u32 = 0;
         let mut fail_count: u32 = 0;
         let mut total_sent: i128 = 0;

--- a/contracts/bulk_payment/src/test.rs
+++ b/contracts/bulk_payment/src/test.rs
@@ -37,6 +37,23 @@ fn setup() -> (Env, Address, Address, BulkPaymentContractClient<'static>) {
     (env, sender, token_id, client)
 }
 
+fn setup_with_sender_balance(sender_balance: i128) -> (Env, Address, Address, BulkPaymentContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let sender = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_id).mint(&sender, &sender_balance);
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(BulkPaymentContract,());
+    let client = BulkPaymentContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    (env, sender, token_id, client)
+}
+
 fn one_payment(env: &Env) -> Vec<PaymentOp> {
     let mut payments: Vec<PaymentOp> = Vec::new(env);
     payments.push_back(PaymentOp { recipient: Address::generate(env), amount: 10 });
@@ -109,6 +126,16 @@ fn test_execute_batch_negative_amount_panics() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_execute_batch_amount_overflow_panics() {
+    let (env, sender, token, client) = setup();
+    let mut payments: Vec<PaymentOp> = Vec::new(&env);
+    payments.push_back(PaymentOp { recipient: Address::generate(&env), amount: i128::MAX });
+    payments.push_back(PaymentOp { recipient: Address::generate(&env), amount: 1 });
+    client.execute_batch(&sender, &token, &payments, &0);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #8)")]
 fn test_execute_batch_sequence_replay_panics() {
     let (env, sender, token, client) = setup();
@@ -144,64 +171,17 @@ fn test_batch_count_increments() {
 
 #[test]
 fn test_partial_batch_skips_insufficient_funds() {
-    let (env, sender, token, client) = setup();
-    // sender has 1_000_000 total minted.
-    // Pull = 500_000 + 600_000 = 1_100_000 which would exceed balance.
-    // Use amounts whose SUM fits within 1_000_000 but where the second
-    // payment exceeds what's left after the first succeeds.
-    //   first:  500_000  → succeeds, remaining = 500_000
-    //   second: 600_000  → skipped  (600_000 > 500_000 remaining)
-    //   refund: 500_000 back to sender
-    // Total pulled = 500_000 + 600_000 = 1_100_000 — still too much.
-    //
-    // Correct approach: pull only positive amounts into total, so
-    // total pulled = 500_000 + 600_000.  Still > 1_000_000.
-    //
-    // We must keep total ≤ 1_000_000.  Use:
-    //   first:  700_000  → succeeds, remaining = 300_000
-    //   second: 400_000  → skipped  (400_000 > 300_000 remaining)
-    //   total pulled = 700_000 + 400_000 = 1_100_000  — still over.
-    //
-    // The contract sums ALL positive amounts before the first transfer,
-    // so both amounts count toward the pull. The only way to have a
-    // "skip due to insufficient remaining" is when the FIRST payment
-    // consumes most of the balance and the second can't fit — but the
-    // total of both must still be ≤ the sender's balance so the pull
-    // itself succeeds.
-    //
-    // Use:  first = 600_000, second = 300_000, total pull = 900_000 ≤ 1_000_000
-    // After first:  remaining = 900_000 - 600_000 = 300_000
-    // Second needs 300_000 → exactly fits, both succeed.  Not what we want.
-    //
-    // Use:  first = 600_000, second = 350_000, total = 950_000 ≤ 1_000_000
-    // After first:  remaining = 950_000 - 600_000 = 350_000 → second fits.
-    //
-    // Use:  first = 700_000, second = 200_000, total = 900_000 ≤ 1_000_000
-    // After first:  remaining = 900_000 - 700_000 = 200_000 → second fits.
-    //
-    // We need remaining < second_amount after first succeeds:
-    //   remaining = total - first = (first + second) - first = second
-    //   → remaining always equals second, so second always fits!
-    //
-    // To force a skip we need a THIRD payment that won't fit:
-    //   first = 500_000, second = 300_000, third = 250_000
-    //   total pull = 1_050_000 > 1_000_000  — over.
-    //
-    // Only workable pattern: make second amount > total - first
-    //   i.e. second > total - first  → impossible since total = first + second.
-    //
-    // Conclusion: with two positive payments the second can NEVER be skipped
-    // for "insufficient remaining" because the contract pre-pulls the full sum.
-    // We must mint MORE tokens or use a negative/zero amount to force a skip.
-    //
-    // Simplest fix: push a zero-amount op (skipped because amount <= 0).
+    // With partial-mode semantics, the contract pulls up to the sender's current
+    // balance (instead of the full requested total), then pays sequentially until
+    // it can't cover the next payment.
+    let (env, sender, token, client) = setup_with_sender_balance(600);
 
     let r1 = Address::generate(&env);
-    let r2 = Address::generate(&env); // will be skipped (amount = 0)
+    let r2 = Address::generate(&env);
 
     let mut payments: Vec<PaymentOp> = Vec::new(&env);
-    payments.push_back(PaymentOp { recipient: r1.clone(), amount: 500_000 });
-    payments.push_back(PaymentOp { recipient: r2.clone(), amount: 0 }); // invalid → skip
+    payments.push_back(PaymentOp { recipient: r1.clone(), amount: 500 });
+    payments.push_back(PaymentOp { recipient: r2.clone(), amount: 400 });
 
     let batch_id =
         client.execute_batch_partial(&sender, &token, &payments, &client.get_sequence());
@@ -211,9 +191,9 @@ fn test_partial_batch_skips_insufficient_funds() {
     assert_eq!(record.fail_count, 1);
 
     let tc = TokenClient::new(&env, &token);
-    assert_eq!(tc.balance(&r1), 500_000);
+    assert_eq!(tc.balance(&r1), 500);
     assert_eq!(tc.balance(&r2), 0);
-    assert_eq!(tc.balance(&sender), 500_000); // refunded the unspent pull
+    assert_eq!(tc.balance(&sender), 100); // refunded the unspent pull
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Make `bulk_payment` mainnet-ready by fixing partial-batch semantics for true best-effort payouts and expanding edge-case test coverage.

Closes #129

## Changes
- **bulk_payment contract**
  - [execute_batch_partial](cci:1://file:///Users/mac/Documents/DripsOS/PayD/contracts/bulk_payment/src/lib.rs:153:4-243:5) now pulls **only what the sender can actually cover**:
    - compute total requested
    - read sender token balance
    - pull `min(total_requested, sender_balance)`
    - pay sequentially until remaining is insufficient
    - refund remainder
  - This enables real “skip due to insufficient funds” behavior without reverting at the initial pull.

- **Tests**
  - Added overflow coverage for total amount computation (`AmountOverflow`)
  - Updated partial-batch test to validate insufficient-funds skipping semantics

## Testing
- `cargo test -p bulk_payment`
- `cargo test`