### PR TITLE
feat: add employee drag-and-drop reordering (#65)

### DIFF
--- a/backend/src/db/migrations/021_add_sort_order_to_employees.sql
+++ b/backend/src/db/migrations/021_add_sort_order_to_employees.sql
@@ -1,0 +1,29 @@
+-- Migration 021: Add persistent sort ordering for employees
+ALTER TABLE employees
+ADD COLUMN IF NOT EXISTS sort_order INTEGER;
+
+WITH ordered_employees AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY organization_id
+      ORDER BY created_at DESC, id DESC
+    ) AS new_sort_order
+  FROM employees
+  WHERE deleted_at IS NULL
+)
+UPDATE employees e
+SET sort_order = ordered_employees.new_sort_order
+FROM ordered_employees
+WHERE e.id = ordered_employees.id
+  AND e.sort_order IS NULL;
+
+ALTER TABLE employees
+ALTER COLUMN sort_order SET DEFAULT 0;
+
+UPDATE employees
+SET sort_order = 0
+WHERE sort_order IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_employees_org_sort_order
+ON employees (organization_id, sort_order, created_at DESC);

--- a/backend/src/schemas/employeeSchema.ts
+++ b/backend/src/schemas/employeeSchema.ts
@@ -11,6 +11,7 @@ export const createEmployeeSchema = z.object({
   status: z.enum(['active', 'inactive', 'pending']).optional().default('active'),
   base_salary: z.number().nonnegative().optional().default(0),
   base_currency: z.string().max(12).optional().default('USDC'),
+  sort_order: z.number().int().nonnegative().optional().default(0),
 });
 
 export const updateEmployeeSchema = createEmployeeSchema.partial().omit({ organization_id: true });

--- a/backend/src/services/employeeService.ts
+++ b/backend/src/services/employeeService.ts
@@ -19,13 +19,14 @@ export class EmployeeService {
       status,
       base_salary,
       base_currency,
+      sort_order,
     } = data;
 
     const query = `
       INSERT INTO employees (
-        organization_id, first_name, last_name, email, wallet_address, position, department, status, base_salary, base_currency
+        organization_id, first_name, last_name, email, wallet_address, position, department, status, base_salary, base_currency, sort_order
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       RETURNING *;
     `;
 
@@ -40,6 +41,7 @@ export class EmployeeService {
       status || 'active',
       base_salary || 0,
       base_currency || 'USDC',
+      sort_order ?? 0,
     ];
 
     const result = await executor.query(query, values);
@@ -85,7 +87,7 @@ export class EmployeeService {
       paramIndex++;
     }
 
-    query += ` ORDER BY created_at DESC LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
+    query += ` ORDER BY sort_order ASC, created_at DESC LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
     values.push(limit, offset);
 
     const result = await pool.query(query, values);

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
+import { DragDropContext, Draggable, Droppable, type DropResult } from '@hello-pangea/dnd';
 import { Avatar } from './Avatar';
 import { CSVUploader } from './CSVUploader';
 import type { CSVRow } from './CSVUploader';
-import { Pencil, Trash2 } from 'lucide-react';
+import { GripVertical, Pencil, Trash2 } from 'lucide-react';
 
 interface Employee {
   id: string;
@@ -13,6 +14,7 @@ interface Employee {
   wallet?: string;
   salary?: number;
   status?: 'Active' | 'Inactive';
+  sortOrder?: number;
 }
 
 interface EmployeeListProps {
@@ -21,6 +23,8 @@ interface EmployeeListProps {
   onAddEmployee: (employee: Employee) => void;
   onEditEmployee?: (employee: Employee) => void;
   onRemoveEmployee?: (id: string) => void;
+  onReorderEmployees?: (employees: Employee[]) => void;
+  isReordering?: boolean;
 }
 
 export const EmployeeList: React.FC<EmployeeListProps> = ({
@@ -28,6 +32,8 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
   onAddEmployee,
   onEditEmployee,
   onRemoveEmployee,
+  onReorderEmployees,
+  isReordering = false,
 }) => {
   const [csvData, setCsvData] = useState<Employee[]>([]);
   const [showCSVUploader, setShowCSVUploader] = useState(false);
@@ -38,7 +44,7 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<{ open: boolean; id?: string }>({
     open: false,
   });
-  const [sortKey, setSortKey] = useState<keyof Employee>('name');
+  const [sortKey, setSortKey] = useState<keyof Employee>('sortOrder');
   const [sortAsc, setSortAsc] = useState(true);
 
   const handleDataParsed = (data: CSVRow[]) => {
@@ -81,6 +87,8 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
       ? String(valA).localeCompare(String(valB))
       : String(valB).localeCompare(String(valA));
   });
+
+  const displayedEmployees = onReorderEmployees ? employees : sortedEmployees;
 
   const shortenWallet = (wallet: string) => {
     if (!wallet) return '';
@@ -136,142 +144,210 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
     setShowDeleteConfirm({ open: false });
   };
 
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination || !onReorderEmployees) return;
+
+    if (result.destination.index === result.source.index) {
+      return;
+    }
+
+    const reorderedEmployees = [...displayedEmployees];
+    const [movedEmployee] = reorderedEmployees.splice(result.source.index, 1);
+    reorderedEmployees.splice(result.destination.index, 0, movedEmployee);
+    onReorderEmployees(
+      reorderedEmployees.map((employee, index) => ({
+        ...employee,
+        sortOrder: index,
+      }))
+    );
+  };
+
   return (
     <div className="w-full card glass noise overflow-hidden p-0">
       <div className="flex justify-between items-center p-4 md:p-6">
-        <span className="font-bold text-lg md:text-xl">Employees</span>
+        <div className="flex items-center gap-3">
+          <span className="font-bold text-lg md:text-xl">Employees</span>
+          {onReorderEmployees && (
+            <span className="text-[10px] uppercase tracking-widest text-muted">
+              Drag rows to reorder
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Desktop Table View */}
       <div className="hidden md:block overflow-x-auto">
-        <table className="w-full text-left border-collapse">
-          <thead>
-            <tr className="border-b border-hi">
-              <th
-                className="p-6 text-xs font-bold uppercase tracking-widest text-muted cursor-pointer"
-                onClick={() => handleSort('name')}
-              >
-                Name {sortKey === 'name' && (sortAsc ? '▲' : '▼')}
-              </th>
-              <th
-                className="p-6 text-xs font-bold uppercase tracking-widest text-muted cursor-pointer"
-                onClick={() => handleSort('position')}
-              >
-                Role {sortKey === 'position' && (sortAsc ? '▲' : '▼')}
-              </th>
-              <th
-                className="p-6 text-xs font-bold uppercase tracking-widest text-muted cursor-pointer"
-                onClick={() => handleSort('wallet')}
-              >
-                Wallet {sortKey === 'wallet' && (sortAsc ? '▲' : '▼')}
-              </th>
-              <th
-                className="p-6 text-xs font-bold uppercase tracking-widest text-muted cursor-pointer"
-                onClick={() => handleSort('salary')}
-              >
-                Salary {sortKey === 'salary' && (sortAsc ? '▲' : '▼')}
-              </th>
-              <th
-                className="p-6 text-xs font-bold uppercase tracking-widest text-muted cursor-pointer"
-                onClick={() => handleSort('status')}
-              >
-                Status {sortKey === 'status' && (sortAsc ? '▲' : '▼')}
-              </th>
-              <th className="p-6 text-xs font-bold uppercase tracking-widest text-muted">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {sortedEmployees.length === 0 ? (
-              <tr>
-                <td colSpan={6} className="p-6 text-center text-gray-500">
-                  No employees found
-                </td>
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="border-b border-hi">
+                <th className="w-14 p-6 text-xs font-bold uppercase tracking-widest text-muted">
+                  Move
+                </th>
+                <th
+                  className={`p-6 text-xs font-bold uppercase tracking-widest text-muted ${onReorderEmployees ? '' : 'cursor-pointer'}`}
+                  onClick={() => {
+                    if (!onReorderEmployees) handleSort('name');
+                  }}
+                >
+                  Name {!onReorderEmployees && sortKey === 'name' && (sortAsc ? '▲' : '▼')}
+                </th>
+                <th
+                  className={`p-6 text-xs font-bold uppercase tracking-widest text-muted ${onReorderEmployees ? '' : 'cursor-pointer'}`}
+                  onClick={() => {
+                    if (!onReorderEmployees) handleSort('position');
+                  }}
+                >
+                  Role {!onReorderEmployees && sortKey === 'position' && (sortAsc ? '▲' : '▼')}
+                </th>
+                <th
+                  className={`p-6 text-xs font-bold uppercase tracking-widest text-muted ${onReorderEmployees ? '' : 'cursor-pointer'}`}
+                  onClick={() => {
+                    if (!onReorderEmployees) handleSort('wallet');
+                  }}
+                >
+                  Wallet {!onReorderEmployees && sortKey === 'wallet' && (sortAsc ? '▲' : '▼')}
+                </th>
+                <th
+                  className={`p-6 text-xs font-bold uppercase tracking-widest text-muted ${onReorderEmployees ? '' : 'cursor-pointer'}`}
+                  onClick={() => {
+                    if (!onReorderEmployees) handleSort('salary');
+                  }}
+                >
+                  Salary {!onReorderEmployees && sortKey === 'salary' && (sortAsc ? '▲' : '▼')}
+                </th>
+                <th
+                  className={`p-6 text-xs font-bold uppercase tracking-widest text-muted ${onReorderEmployees ? '' : 'cursor-pointer'}`}
+                  onClick={() => {
+                    if (!onReorderEmployees) handleSort('status');
+                  }}
+                >
+                  Status {!onReorderEmployees && sortKey === 'status' && (sortAsc ? '▲' : '▼')}
+                </th>
+                <th className="p-6 text-xs font-bold uppercase tracking-widest text-muted">
+                  Actions
+                </th>
               </tr>
-            ) : (
-              sortedEmployees.map((employee) => (
-                <tr key={employee.id} className="cursor-pointer transition">
-                  <td className="p-6">
-                    <div className="flex items-center gap-3">
-                      <Avatar
-                        email={employee.email}
-                        name={employee.name}
-                        imageUrl={employee.imageUrl}
-                        size="sm"
-                      />
-                      <span className="text-xs text-muted">{employee.name}</span>
-                    </div>
-                  </td>
-                  <td className="p-6 text-sm font-medium">{employee.position}</td>
-                  <td className="p-6 font-mono text-xs text-muted">
-                    {shortenWallet(employee.wallet || '')}
-                  </td>
-                  <td className="p-6">
-                    {/* Inline salary edit */}
-                    {onEditEmployee ? (
-                      <button
-                        className="text-blue-500 underline"
-                        onClick={() => {
-                          setEditSalary(employee.salary || 0);
-                          setShowEditModal({ open: true, employee });
-                        }}
-                      >
-                        {employee.salary ?? 0}
-                      </button>
-                    ) : (
-                      (employee.salary ?? 0)
-                    )}
-                  </td>
-                  <td className="p-6">
-                    <span
-                      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider border ${
-                        employee.status === 'Active'
-                          ? 'bg-green-100 text-green-600 border-green-200'
-                          : 'bg-red-100 text-red-600 border-red-200'
-                      }`}
-                    >
-                      <div
-                        className={`w-1 h-1 rounded-full ${
-                          employee.status === 'Active' ? 'bg-green-600' : 'bg-red-600'
-                        }`}
-                      />
-                      {employee.status || '-'}
-                    </span>
-                  </td>
-                  <td className="p-6 flex gap-2">
-                    <button
-                      className="text-blue-500 hover:text-blue-700"
-                      title="Edit"
-                      onClick={() => {
-                        setEditSalary(employee.salary || 0);
-                        setShowEditModal({ open: true, employee });
-                      }}
-                    >
-                      <Pencil className="w-5 h-5" />
-                    </button>
-                    <button
-                      className="text-red-500 hover:text-red-700"
-                      title="Remove"
-                      onClick={() => setShowDeleteConfirm({ open: true, id: employee.id })}
-                    >
-                      <Trash2 className="w-5 h-5" />
-                    </button>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <Droppable droppableId="employee-table">
+              {(provided) => (
+                <tbody
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  className="divide-y divide-gray-200"
+                >
+                  {displayedEmployees.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="p-6 text-center text-gray-500">
+                        No employees found
+                      </td>
+                    </tr>
+                  ) : (
+                    displayedEmployees.map((employee, index) => (
+                      <Draggable key={employee.id} draggableId={employee.id} index={index}>
+                        {(dragProvided, snapshot) => (
+                          <tr
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            className={`cursor-pointer transition ${snapshot.isDragging ? 'bg-accent/10 shadow-lg shadow-accent/10' : ''}`}
+                          >
+                            <td className="p-6">
+                              <button
+                                type="button"
+                                {...dragProvided.dragHandleProps}
+                                disabled={isReordering}
+                                className="rounded-lg border border-hi p-2 text-muted hover:text-text hover:border-accent transition-colors disabled:opacity-50"
+                                aria-label={`Reorder ${employee.name}`}
+                                title="Drag to reorder"
+                              >
+                                <GripVertical className="w-4 h-4" />
+                              </button>
+                            </td>
+                            <td className="p-6">
+                              <div className="flex items-center gap-3">
+                                <Avatar
+                                  email={employee.email}
+                                  name={employee.name}
+                                  imageUrl={employee.imageUrl}
+                                  size="sm"
+                                />
+                                <span className="text-xs text-muted">{employee.name}</span>
+                              </div>
+                            </td>
+                            <td className="p-6 text-sm font-medium">{employee.position}</td>
+                            <td className="p-6 font-mono text-xs text-muted">
+                              {shortenWallet(employee.wallet || '')}
+                            </td>
+                            <td className="p-6">
+                              {onEditEmployee ? (
+                                <button
+                                  className="text-blue-500 underline"
+                                  onClick={() => {
+                                    setEditSalary(employee.salary || 0);
+                                    setShowEditModal({ open: true, employee });
+                                  }}
+                                >
+                                  {employee.salary ?? 0}
+                                </button>
+                              ) : (
+                                (employee.salary ?? 0)
+                              )}
+                            </td>
+                            <td className="p-6">
+                              <span
+                                className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider border ${
+                                  employee.status === 'Active'
+                                    ? 'bg-green-100 text-green-600 border-green-200'
+                                    : 'bg-red-100 text-red-600 border-red-200'
+                                }`}
+                              >
+                                <div
+                                  className={`w-1 h-1 rounded-full ${
+                                    employee.status === 'Active' ? 'bg-green-600' : 'bg-red-600'
+                                  }`}
+                                />
+                                {employee.status || '-'}
+                              </span>
+                            </td>
+                            <td className="p-6 flex gap-2">
+                              <button
+                                className="text-blue-500 hover:text-blue-700"
+                                title="Edit"
+                                onClick={() => {
+                                  setEditSalary(employee.salary || 0);
+                                  setShowEditModal({ open: true, employee });
+                                }}
+                              >
+                                <Pencil className="w-5 h-5" />
+                              </button>
+                              <button
+                                className="text-red-500 hover:text-red-700"
+                                title="Remove"
+                                onClick={() => setShowDeleteConfirm({ open: true, id: employee.id })}
+                              >
+                                <Trash2 className="w-5 h-5" />
+                              </button>
+                            </td>
+                          </tr>
+                        )}
+                      </Draggable>
+                    ))
+                  )}
+                  {provided.placeholder}
+                </tbody>
+              )}
+            </Droppable>
+          </table>
+        </DragDropContext>
       </div>
 
       {/* Mobile Card View */}
       <div className="md:hidden px-4 pb-4">
-        {sortedEmployees.length === 0 ? (
+        {displayedEmployees.length === 0 ? (
           <div className="text-center py-8 text-gray-500">No employees found</div>
         ) : (
           <div className="space-y-4">
-            {sortedEmployees.map((employee) => (
+            {displayedEmployees.map((employee) => (
               <div key={employee.id} className="bg-white/5 rounded-lg p-4 border border-white/10">
                 {/* Employee Header */}
                 <div className="flex items-center justify-between mb-3">

--- a/frontend/src/components/EmployeeList.tsx
+++ b/frontend/src/components/EmployeeList.tsx
@@ -323,7 +323,9 @@ export const EmployeeList: React.FC<EmployeeListProps> = ({
                               <button
                                 className="text-red-500 hover:text-red-700"
                                 title="Remove"
-                                onClick={() => setShowDeleteConfirm({ open: true, id: employee.id })}
+                                onClick={() =>
+                                  setShowDeleteConfirm({ open: true, id: employee.id })
+                                }
                               >
                                 <Trash2 className="w-5 h-5" />
                               </button>

--- a/frontend/src/pages/EmployeeEntry.tsx
+++ b/frontend/src/pages/EmployeeEntry.tsx
@@ -11,7 +11,7 @@ import { useNotification } from '../hooks/useNotification';
 
 import api from '../utils/api';
 
-interface EmployeeApiResponse {
+interface EmployeeApiRecord {
   id: number | string;
   first_name: string;
   last_name: string;
@@ -23,8 +23,8 @@ interface EmployeeApiResponse {
   sort_order?: number;
 }
 
-interface EmployeesApiResponse {
-  data: EmployeeApiResponse[];
+interface EmployeeListResponse {
+  data: EmployeeApiRecord[];
   pagination?: unknown;
 }
 
@@ -87,7 +87,7 @@ export default function EmployeeEntry() {
   const fetchEmployees = useCallback(async () => {
     try {
       setLoading(true);
-      const response = await api.get<EmployeesApiResponse>('/employees');
+      const response = await api.get<EmployeeListResponse>('/employees');
       // Backend returns { data: [...], pagination: {...} }
       const mapped: EmployeeItem[] = response.data.data.map((emp) => ({
         id: String(emp.id),

--- a/frontend/src/pages/EmployeeEntry.tsx
+++ b/frontend/src/pages/EmployeeEntry.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { isAxiosError } from 'axios';
 import { Icon, Button, Card, Input, Select, Alert } from '@stellar/design-system';
 import { EmployeeList } from '../components/EmployeeList';
 import { AutosaveIndicator } from '../components/AutosaveIndicator';
@@ -9,6 +10,32 @@ import { useTranslation } from 'react-i18next';
 import { useNotification } from '../hooks/useNotification';
 
 import api from '../utils/api';
+
+interface EmployeeApiResponse {
+  id: number | string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  position?: string;
+  job_title?: string;
+  wallet_address?: string;
+  status?: string;
+  sort_order?: number;
+}
+
+interface EmployeesApiResponse {
+  data: EmployeeApiResponse[];
+  pagination?: unknown;
+}
+
+function hasErrorMessage(value: unknown): value is { error: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'error' in value &&
+    typeof value.error === 'string'
+  );
+}
 
 interface EmployeeFormState {
   fullName: string;
@@ -26,6 +53,7 @@ interface EmployeeItem {
   position: string;
   wallet?: string;
   status?: 'Active' | 'Inactive';
+  sortOrder?: number;
 }
 
 const initialFormState: EmployeeFormState = {
@@ -41,6 +69,7 @@ export default function EmployeeEntry() {
   const [formData, setFormData] = useState<EmployeeFormState>(initialFormState);
   const [employees, setEmployees] = useState<EmployeeItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isReordering, setIsReordering] = useState(false);
   const [notification, setNotification] = useState<{
     message: string;
     secretKey?: string;
@@ -48,28 +77,12 @@ export default function EmployeeEntry() {
     employeeName?: string;
   } | null>(null);
 
-  const { notifySuccess } = useNotification();
+  const { notifySuccess, notifyError } = useNotification();
   const { saving, lastSaved, loadSavedData } = useAutosave<EmployeeFormState>(
     'employee-entry-draft',
     formData
   );
   const { t } = useTranslation();
-
-  interface EmployeeApiResponse {
-    id: number;
-    first_name: string;
-    last_name: string;
-    email: string;
-    position?: string;
-    job_title?: string;
-    wallet_address?: string;
-    status: string;
-  }
-
-  interface EmployeesApiResponse {
-    data: EmployeeApiResponse[];
-    pagination?: unknown;
-  }
 
   const fetchEmployees = useCallback(async () => {
     try {
@@ -82,7 +95,8 @@ export default function EmployeeEntry() {
         email: emp.email,
         position: emp.position ?? emp.job_title ?? 'Employee',
         wallet: emp.wallet_address,
-        status: emp.status === 'active' ? ('Active' as const) : ('Inactive' as const),
+        status: emp.status === 'active' ? 'Active' : 'Inactive',
+        sortOrder: emp.sort_order ?? 0,
       }));
       setEmployees(mapped);
     } catch (err) {
@@ -135,6 +149,7 @@ export default function EmployeeEntry() {
       base_salary: 0, // Default for now
       base_currency: formData.currency,
       status: 'active',
+      sort_order: employees.length,
     };
 
     try {
@@ -159,6 +174,41 @@ export default function EmployeeEntry() {
       void fetchEmployees();
     } catch (error) {
       console.error('Failed to add employee:', error);
+    }
+  };
+
+  const handleReorderEmployees = async (reorderedEmployees: EmployeeItem[]) => {
+    const previousEmployees = employees;
+    setEmployees(reorderedEmployees);
+    setIsReordering(true);
+
+    try {
+      await Promise.all(
+        reorderedEmployees.map((employee, index) =>
+          api.patch(`/employees/${employee.id}`, {
+            sort_order: index,
+          })
+        )
+      );
+
+      notifySuccess('Employee order updated', 'The new table order has been saved.');
+    } catch (error) {
+      console.error('Failed to reorder employees:', error);
+      setEmployees(previousEmployees);
+
+      const responseData: unknown = isAxiosError(error) ? error.response?.data : undefined;
+      const message = hasErrorMessage(responseData)
+        ? responseData.error
+        : isAxiosError(error)
+          ? error.message
+          : 'Unable to save the new employee order.';
+
+      notifyError(
+        'Failed to save employee order',
+        typeof message === 'string' ? message : 'Unable to save the new employee order.'
+      );
+    } finally {
+      setIsReordering(false);
     }
   };
 
@@ -352,6 +402,10 @@ export default function EmployeeEntry() {
           employees={employees}
           onEmployeeClick={(employee: EmployeeItem) => console.log('Clicked:', employee.name)}
           onAddEmployee={(employee: EmployeeItem) => console.log('Added:', employee)}
+          onReorderEmployees={(items: EmployeeItem[]) => {
+            void handleReorderEmployees(items);
+          }}
+          isReordering={isReordering}
         />
       )}
     </div>


### PR DESCRIPTION
Closes #65

## Changes
- added drag-and-drop reordering to the employee management table
- added a visible drag handle on each desktop table row
- added visual feedback while rows are being dragged
- persisted employee order to the backend using `sort_order`
- updated employee reads to return employees in saved manual order
- added a database migration to backfill and index `sort_order`
- rolled back the UI order if persistence fails and surfaced an error toast

## Testing
- `npm run build` in `frontend`

## Notes
- this implementation adds backend support because the existing employee API had no persistent ordering field
- reorder is currently enabled in the desktop management table view
