### PR TITLE
Me/rehm/gf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
 name = "bulk_payment"
 version = "0.0.1"
 dependencies = [
+ "common",
  "soroban-sdk",
 ]
 
@@ -260,6 +261,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "common"
+version = "0.0.1"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +303,7 @@ dependencies = [
 name = "cross_asset_payment"
 version = "0.0.1"
 dependencies = [
+ "common",
  "soroban-sdk",
  "stellar-access",
  "stellar-macros",
@@ -1006,6 +1015,7 @@ dependencies = [
 name = "revenue_split"
 version = "0.0.1"
 dependencies = [
+ "common",
  "soroban-sdk",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "contracts/common",
   "contracts/bulk_payment",
   "contracts/revenue_split",
   "contracts/cross_asset_payment",

--- a/contracts/bulk_payment/Cargo.toml
+++ b/contracts/bulk_payment/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/bulk_payment/src/lib.rs
+++ b/contracts/bulk_payment/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, contracterror, contractevent,
     Address, Env, Vec, token,
 };
+use common::CommonError;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +21,16 @@ pub enum ContractError {
     AmountOverflow     = 7,
     SequenceMismatch   = 8,
     BatchNotFound      = 9,
+}
+
+impl From<CommonError> for ContractError {
+    fn from(e: CommonError) -> Self {
+        match e {
+            CommonError::AlreadyInitialized => ContractError::AlreadyInitialized,
+            CommonError::NotInitialized => ContractError::NotInitialized,
+            CommonError::Unauthorized => ContractError::Unauthorized,
+        }
+    }
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -97,7 +108,7 @@ impl BulkPaymentContract {
     }
 
     pub fn set_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
-        Self::require_admin(&env)?;
+        common::require_admin(&env, &DataKey::Admin).map_err(ContractError::from)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         Ok(())
     }
@@ -259,16 +270,6 @@ impl BulkPaymentContract {
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
-
-    fn require_admin(env: &Env) -> Result<(), ContractError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(ContractError::NotInitialized)?;
-        admin.require_auth();
-        Ok(())
-    }
 
     fn check_and_advance_sequence(env: &Env, expected: u64) -> Result<(), ContractError> {
         let current: u64 = env.storage().instance().get(&DataKey::Sequence).unwrap_or(0);

--- a/contracts/common/Cargo.toml
+++ b/contracts/common/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "common"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/contracts/common/src/lib.rs
+++ b/contracts/common/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+
+use soroban_sdk::{contracterror, Address, Env, IntoVal, Val};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum CommonError {
+    AlreadyInitialized = 1,
+    NotInitialized     = 2,
+    Unauthorized       = 3,
+}
+
+/// Reads the admin address from instance storage at the given key, verifies the
+/// caller has authorized this contract call, and returns the admin address.
+pub fn require_admin<K: IntoVal<Env, Val>>(
+    env: &Env,
+    admin_key: &K,
+) -> Result<Address, CommonError> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(admin_key)
+        .ok_or(CommonError::NotInitialized)?;
+    admin.require_auth();
+    Ok(admin)
+}

--- a/contracts/cross_asset_payment/Cargo.toml
+++ b/contracts/cross_asset_payment/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { workspace = true }
 stellar-access = { workspace = true }
 stellar-macros = { workspace = true }
 stellar-tokens = { workspace = true }
+common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/cross_asset_payment/src/lib.rs
+++ b/contracts/cross_asset_payment/src/lib.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, contracterror, contractevent,
     symbol_short, Address, Env, String, Symbol, token,
 };
+use common::CommonError;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -18,6 +19,16 @@ pub enum ContractError {
     InvalidAmount      = 5,
     NotPending         = 6,
     InvalidFeeRate     = 7,
+}
+
+impl From<CommonError> for ContractError {
+    fn from(e: CommonError) -> Self {
+        match e {
+            CommonError::AlreadyInitialized => ContractError::AlreadyInitialized,
+            CommonError::NotInitialized => ContractError::NotInitialized,
+            CommonError::Unauthorized => ContractError::Unauthorized,
+        }
+    }
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -95,7 +106,7 @@ impl CrossAssetPaymentContract {
         if fee_rate_bps > MAX_FEE_BPS {
             return Err(ContractError::InvalidFeeRate);
         }
-        Self::require_admin(&env)?;
+        common::require_admin(&env, &DataKey::Admin).map_err(ContractError::from)?;
         env.storage().instance().set(&DataKey::FeeRateBps, &fee_rate_bps);
         Ok(())
     }
@@ -182,7 +193,7 @@ impl CrossAssetPaymentContract {
         payment_id: u64,
         new_status: Symbol,
     ) -> Result<(), ContractError> {
-        Self::require_admin(&env)?;
+        common::require_admin(&env, &DataKey::Admin).map_err(ContractError::from)?;
 
         let mut record: PaymentRecord = env.storage().persistent()
             .get(&DataKey::Payment(payment_id))
@@ -249,15 +260,6 @@ impl CrossAssetPaymentContract {
         env.storage().instance().get(&DataKey::PaymentCount).unwrap_or(0)
     }
 
-    // ── Private helpers ───────────────────────────────────────────────────────
-
-    fn require_admin(env: &Env) -> Result<Address, ContractError> {
-        let admin: Address = env.storage().instance()
-            .get(&DataKey::Admin)
-            .ok_or(ContractError::NotInitialized)?;
-        admin.require_auth();
-        Ok(admin)
-    }
 }
 
 mod test;

--- a/contracts/revenue_split/Cargo.toml
+++ b/contracts/revenue_split/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 soroban-sdk = { workspace = true }
+common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/revenue_split/src/lib.rs
+++ b/contracts/revenue_split/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Vec, token};
+use common::CommonError;
 
 #[cfg(test)]
 mod test;
@@ -22,6 +23,16 @@ pub enum ContractError {
     DuplicateRecipient = 5,
     SharesMustSumToTotal = 6,
     InvalidAmount = 7,
+}
+
+impl From<CommonError> for ContractError {
+    fn from(e: CommonError) -> Self {
+        match e {
+            CommonError::AlreadyInitialized => ContractError::AlreadyInitialized,
+            CommonError::NotInitialized => ContractError::NotInitialized,
+            CommonError::Unauthorized => ContractError::Unauthorized,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -56,14 +67,14 @@ impl RevenueSplitContract {
 
     /// Allows the current admin to set a new admin.
     pub fn set_admin(env: Env, new_admin: Address) -> Result<(), ContractError> {
-        Self::require_admin(&env)?;
+        common::require_admin(&env, &DataKey::Admin).map_err(ContractError::from)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         Ok(())
     }
 
     /// Updates the recipient splits dynamically (admin only).
     pub fn update_recipients(env: Env, new_shares: Vec<RecipientShare>) -> Result<(), ContractError> {
-        Self::require_admin(&env)?;
+        common::require_admin(&env, &DataKey::Admin).map_err(ContractError::from)?;
 
         Self::validate_shares(&env, &new_shares)?;
 
@@ -113,18 +124,6 @@ impl RevenueSplitContract {
         }
 
         Ok(())
-    }
-
-    fn require_admin(env: &Env) -> Result<Address, ContractError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(ContractError::NotInitialized)?;
-
-        // require_auth traps on failure; we also convert missing init to a typed error above.
-        admin.require_auth();
-        Ok(admin)
     }
 
     fn validate_shares(env: &Env, shares: &Vec<RecipientShare>) -> Result<(), ContractError> {


### PR DESCRIPTION
Summary
- Introduces contracts/common, a shared no_std workspace crate housing the duplicated CommonError variants and the require_admin admin-guard helper pattern
- Refactors bulk_payment, cross_asset_payment, and revenue_split to consume the shared crate, removing copy-pasted admin logic and centralizing the auth/error surface
Changes
New crate: contracts/common
- CommonError enum with the three universally-shared variants: AlreadyInitialized = 1, NotInitialized = 2, Unauthorized = 3
- require_admin<K: IntoVal<Env, Val>>(env, admin_key) — generic over the storage key type, reads admin from instance storage, calls require_auth(), returns Result<Address, CommonError>
bulk_payment
- Added common dependency and From<CommonError> for ContractError impl
- Replaced private require_admin helper with common::require_admin(&env, &DataKey::Admin).map_err(ContractError::from)?
- Removed the 9-line duplicated helper
cross_asset_payment
- Same pattern: added common dependency, From impl, replaced require_admin calls
- Removed the 7-line duplicated helper
revenue_split
- Same pattern: added common dependency, From impl, replaced require_admin calls
- Removed the 11-line duplicated helper
Cargo.toml (workspace root)
- Added contracts/common to workspace members
Testing
- 34 tests pass across the full workspace (cargo test --workspace)
  - bulk_payment: 13 passing
  - cross_asset_payment: 12 passing
  - revenue_split: 8 passing
  - vesting_escrow: 1 passing
- All existing should_panic(expected = "Error(Contract, #N)") assertions remain correct — error discriminants unchanged
Tradeoffs
- Each contract still re-declares the shared variants in its own ContractError enum because Soroban's #[contracterror] derive requires them to be local types. The From<CommonError> impl centralizes the mapping so the semantic contract is defined once.
- InvalidAmount remains contract-specific (discriminants differ: bulk=6, cross=5, revenue=7) rather than being moved to the shared crate, preserving existing on-wire error codes.
Out of scope
- vesting_escrow — uses panic!() strings instead of typed errors; its error refactor is a separate issue
- Changing any contract's external behavior or error numbering
Closes #399 