### PR TITLE
test(e2e): add Playwright E2E testing infrastructure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,56 @@
+name: Frontend E2E (Playwright)
+
+# Runs Playwright E2E tests for the frontend. Triggered manually for now
+# (per the initial rollout), and automatically on PRs that touch the frontend.
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/e2e.yml"
+
+defaults:
+  run:
+    working-directory: frontend
+
+jobs:
+  e2e:
+    name: Playwright tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14
+
+      - name: Upload test results (traces, videos, screenshots)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: frontend/test-results/
+          retention-days: 14

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -35,6 +35,12 @@ lerna-debug.log*
 # macOS-specific files
 .DS_Store
 
+# Playwright E2E artifacts
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/blob-report/
+
 # generated contract clients
 packages/*
 # if you have other workspace packages, add them here

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,78 @@
+# Frontend E2E tests (Playwright)
+
+End-to-end tests that exercise critical PayD user flows through a real browser.
+All outbound network traffic (Stellar Horizon, Soroban RPC, backend API) is
+mocked, so tests run offline and never touch the Stellar testnet.
+
+## Running
+
+From the `frontend/` directory:
+
+```bash
+# Install browsers once (Chromium + Firefox)
+npx playwright install
+
+# Run all E2E tests headlessly
+npm run test:e2e
+
+# Interactive UI mode (great for debugging)
+npm run test:e2e:ui
+
+# Run with a visible browser
+npm run test:e2e:headed
+
+# Open the last HTML report
+npm run test:e2e:report
+```
+
+The Vite dev server is started automatically by Playwright (`webServer` in
+`playwright.config.ts`); you don't need to run `npm run dev` yourself.
+
+## Layout
+
+```
+e2e/
+├── fixtures/
+│   └── base.ts          # Extended `test` — auto-seeds auth + mocks network
+├── mocks/
+│   ├── auth.ts          # Seeds a fake logged-in session (no real OAuth)
+│   ├── horizon.ts       # Canned Horizon / Soroban / API response data
+│   └── network.ts       # Route interception + per-test overrides
+├── tests/
+│   ├── login-navigation.spec.ts   # Login page + sidebar navigation
+│   ├── employee.spec.ts           # Employee directory → add → validation
+│   ├── payroll.spec.ts            # Payroll form + scheduling wizard → confirm
+│   ├── wallet.spec.ts             # Wallet connection entry point
+│   └── transactions.spec.ts       # Transaction history display + filtering
+└── README.md
+```
+
+## Writing tests
+
+Import `test` and `expect` from the base fixture — this gives every test a
+seeded auth session and mocked network by default:
+
+```ts
+import { test, expect } from '../fixtures/base';
+
+test('does a thing', async ({ page }) => {
+  await page.goto('/employee');
+  // ...
+});
+```
+
+Opt out per file/describe when needed:
+
+```ts
+test.use({ authenticated: false }); // e.g. the login page
+test.use({ mockNetwork: false });   // to hit routes yourself
+```
+
+To return custom data for a specific endpoint, use `mockRoute` from
+`../mocks/network` after navigating.
+
+## CI
+
+`.github/workflows/e2e.yml` runs these tests on PRs that touch `frontend/**`
+and via manual `workflow_dispatch`. The HTML report and failure artifacts
+(traces, videos, screenshots) are uploaded as build artifacts.

--- a/frontend/e2e/fixtures/base.ts
+++ b/frontend/e2e/fixtures/base.ts
@@ -1,0 +1,36 @@
+import { test as base, expect } from '@playwright/test';
+import { setupNetworkMocks } from '../mocks/network';
+import { seedAuth } from '../mocks/auth';
+
+/**
+ * Base test fixture for PayD E2E tests.
+ *
+ * Every test built on this fixture automatically:
+ *   - has a seeded auth session (no real OAuth login required), and
+ *   - has all outbound network traffic mocked (no real Stellar / backend calls).
+ *
+ * Use `authenticated: false` on a test to opt out of seeded auth (e.g. the
+ * login page test), and `mockNetwork: false` to opt out of network mocking.
+ *
+ *   test('...', async ({ page }) => { ... });                 // both on
+ *   test.use({ authenticated: false });                       // per describe/file
+ */
+export const test = base.extend<{
+  authenticated: boolean;
+  mockNetwork: boolean;
+}>({
+  authenticated: [true, { option: true }],
+  mockNetwork: [true, { option: true }],
+
+  page: async ({ page, authenticated, mockNetwork }, use) => {
+    if (mockNetwork) {
+      await setupNetworkMocks(page);
+    }
+    if (authenticated) {
+      await seedAuth(page);
+    }
+    await use(page);
+  },
+});
+
+export { expect };

--- a/frontend/e2e/mocks/auth.ts
+++ b/frontend/e2e/mocks/auth.ts
@@ -1,0 +1,30 @@
+import type { Page } from '@playwright/test';
+
+/** A syntactically-valid but non-sensitive fake JWT for seeding auth state. */
+const FAKE_JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+  'eyJzdWIiOiJlMmUtdGVzdC11c2VyIiwiZW1haWwiOiJlMmVAcGF5ZC50ZXN0IiwiaWF0IjoxNzAwMDAwMDAwfQ.' +
+  'e2e_signature_not_verified';
+
+/**
+ * Seed a logged-in session so tests skip the real OAuth flow. Runs before any
+ * page script via `addInitScript`, so the tokens are present on every
+ * navigation within the test.
+ *
+ * The app reads several token keys across services (`payd_auth_token` and
+ * `accessToken`), so we set both.
+ */
+export async function seedAuth(page: Page): Promise<void> {
+  await page.addInitScript((token: string) => {
+    try {
+      window.localStorage.setItem('payd_auth_token', token);
+      window.localStorage.setItem('accessToken', token);
+      window.localStorage.setItem(
+        'payd_user',
+        JSON.stringify({ id: 'e2e-test-user', email: 'e2e@payd.test', name: 'E2E Tester' })
+      );
+    } catch {
+      // localStorage may be unavailable in some contexts; ignore.
+    }
+  }, FAKE_JWT);
+}

--- a/frontend/e2e/mocks/horizon.ts
+++ b/frontend/e2e/mocks/horizon.ts
@@ -1,0 +1,96 @@
+/**
+ * Canned Stellar Horizon / Soroban RPC responses used by the E2E network mocks.
+ *
+ * These are intentionally minimal — just enough shape for the app to render
+ * without hitting the real network. Extend as tests need richer data.
+ */
+
+export const TEST_ACCOUNT_ID = 'GBTEST0000000000000000000000000000000000000000000000000000AB';
+
+export const horizonAccount = {
+  id: TEST_ACCOUNT_ID,
+  account_id: TEST_ACCOUNT_ID,
+  sequence: '1234567890',
+  subentry_count: 0,
+  last_modified_ledger: 1,
+  balances: [
+    {
+      balance: '1000.0000000',
+      asset_type: 'native',
+    },
+    {
+      balance: '500.0000000',
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      is_authorized: true,
+    },
+  ],
+  signers: [{ key: TEST_ACCOUNT_ID, weight: 1, type: 'ed25519_public_key' }],
+  data: {},
+  thresholds: { low_threshold: 0, med_threshold: 0, high_threshold: 0 },
+  flags: { auth_required: false, auth_revocable: false, auth_immutable: false },
+};
+
+export const horizonPayments = {
+  _embedded: {
+    records: [
+      {
+        id: '1',
+        type: 'payment',
+        transaction_hash: 'abc123def456abc123def456abc123def456abc123def456abc123def456abcd',
+        from: TEST_ACCOUNT_ID,
+        to: 'GDEST0000000000000000000000000000000000000000000000000000CDEF',
+        amount: '250.0000000',
+        asset_type: 'native',
+        created_at: '2026-01-15T10:00:00Z',
+      },
+    ],
+  },
+};
+
+export const horizonTransactions = {
+  _embedded: { records: [] },
+};
+
+/** Generic Soroban JSON-RPC health / getLatestLedger style response. */
+export function sorobanRpcResponse(id: number | string = 1) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    result: {
+      status: 'healthy',
+      latestLedger: 1000,
+      oldestLedger: 1,
+      ledgerRetentionWindow: 999,
+    },
+  };
+}
+
+/** Empty, successful backend list response used as a default for `/api/**`. */
+export const emptyApiList = {
+  data: [],
+  items: [],
+  results: [],
+  total: 0,
+  page: 1,
+};
+
+/** `GET /api/v1/schedules` — payroll scheduler list. */
+export const schedulesResponse = {
+  schedules: [],
+  pagination: { page: 1, limit: 10, total: 0 },
+};
+
+/** `GET /api/v1/payroll-bonus/runs` — bulk payment status tracker. */
+export const payrollRunsResponse = {
+  success: true,
+  data: { data: [], total: 0 },
+};
+
+/** `GET /api/.../audit` — classic transaction history feed. */
+export const auditResponse = {
+  data: [],
+  total: 0,
+  page: 1,
+};

--- a/frontend/e2e/mocks/network.ts
+++ b/frontend/e2e/mocks/network.ts
@@ -1,0 +1,85 @@
+import type { Page, Route, Request } from '@playwright/test';
+import {
+  horizonAccount,
+  horizonPayments,
+  horizonTransactions,
+  sorobanRpcResponse,
+  emptyApiList,
+  schedulesResponse,
+  payrollRunsResponse,
+  auditResponse,
+} from './horizon';
+
+const JSON_HEADERS = { 'content-type': 'application/json' };
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Intercept all outbound network traffic so E2E tests never touch the real
+ * Stellar network or a backend. Anything not explicitly matched below is
+ * fulfilled with an empty-but-valid JSON payload so the app degrades quietly
+ * instead of hanging on a real request.
+ *
+ * Routes are registered most-specific-first because Playwright evaluates the
+ * most recently registered handler first.
+ */
+export async function setupNetworkMocks(page: Page): Promise<void> {
+  // Friendbot (testnet funding).
+  await page.route(/friendbot/i, (route) => json(route, { successful: true }));
+
+  // Soroban RPC (JSON-RPC POST endpoints).
+  await page.route(/soroban|\/rpc(\b|\/)/i, async (route: Route, request: Request) => {
+    let id: number | string = 1;
+    try {
+      const payload = request.postDataJSON?.() as { id?: number | string } | undefined;
+      if (payload?.id !== undefined) id = payload.id;
+    } catch {
+      // non-JSON body, keep default id
+    }
+    return json(route, sorobanRpcResponse(id));
+  });
+
+  // Stellar Horizon REST endpoints.
+  await page.route(/horizon/i, (route: Route, request: Request) => {
+    const url = request.url();
+    if (/\/accounts\//.test(url)) return json(route, horizonAccount);
+    if (/\/payments\b/.test(url)) return json(route, horizonPayments);
+    if (/\/transactions\b/.test(url)) return json(route, horizonTransactions);
+    return json(route, { _embedded: { records: [] } });
+  });
+
+  // Backend API (dev defaults: localhost:3000 / :3001 and any /api path).
+  await page.route(/localhost:300[01]|\/api\//i, (route: Route, request: Request) => {
+    const url = request.url();
+    if (/\/auth\/(me|session|profile)/.test(url)) {
+      return json(route, { id: 'test-user', email: 'e2e@payd.test', name: 'E2E Tester' });
+    }
+    return json(route, emptyApiList);
+  });
+
+  // Endpoint-specific shapes (registered last so they take precedence over the
+  // generic API handler above — Playwright evaluates the most recent match first).
+  await page.route(/\/payroll-bonus\/runs\b/i, (route) => json(route, payrollRunsResponse));
+  await page.route(/\/schedules\b/i, (route) => json(route, schedulesResponse));
+  await page.route(/\/audit\b/i, (route) => json(route, auditResponse));
+}
+
+/**
+ * Override a single route with a custom response. Useful for testing specific
+ * states (e.g. a failed transaction, a populated transaction list). Registered
+ * after {@link setupNetworkMocks}, so it takes precedence for matching URLs.
+ */
+export async function mockRoute(
+  page: Page,
+  urlPattern: string | RegExp,
+  body: unknown,
+  status = 200
+): Promise<void> {
+  await page.route(urlPattern, (route) => json(route, body, status));
+}

--- a/frontend/e2e/tests/employee.spec.ts
+++ b/frontend/e2e/tests/employee.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../fixtures/base';
+
+/**
+ * Critical flow: Employee directory -> Add employee -> Form + validation.
+ */
+
+test.describe('Employee management', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/employee');
+  });
+
+  test('shows the workforce directory with an add action', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /directory/i })).toBeVisible();
+    await expect(page.locator('#tour-add-employee')).toBeVisible();
+  });
+
+  test('opens the add-employee form', async ({ page }) => {
+    await page.locator('#tour-add-employee').click();
+
+    await expect(page.getByRole('heading', { name: /add new employee/i })).toBeVisible();
+    await expect(page.locator('#fullName')).toBeVisible();
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#walletAddress')).toBeVisible();
+  });
+
+  test('blocks submission when required fields are empty', async ({ page }) => {
+    await page.locator('#tour-add-employee').click();
+
+    // Submit with empty required fields -> native HTML5 validation blocks it.
+    await page.getByRole('button', { name: 'Add Employee', exact: true }).click();
+
+    // Still on the form (submission did not go through).
+    await expect(page.getByRole('heading', { name: /add new employee/i })).toBeVisible();
+
+    // The Full Name field reports itself as invalid.
+    const fullNameInvalid = await page
+      .locator('#fullName')
+      .evaluate((el: HTMLInputElement) => !el.checkValidity());
+    expect(fullNameInvalid).toBe(true);
+  });
+
+  test('accepts a valid employee entry', async ({ page }) => {
+    await page.locator('#tour-add-employee').click();
+
+    await page.locator('#fullName').fill('Ada Lovelace');
+    await page.locator('#email').fill('ada@payd.test');
+
+    // Fields hold their values and pass native validation.
+    await expect(page.locator('#fullName')).toHaveValue('Ada Lovelace');
+    await expect(page.locator('#email')).toHaveValue('ada@payd.test');
+
+    const emailValid = await page
+      .locator('#email')
+      .evaluate((el: HTMLInputElement) => el.checkValidity());
+    expect(emailValid).toBe(true);
+  });
+});

--- a/frontend/e2e/tests/login-navigation.spec.ts
+++ b/frontend/e2e/tests/login-navigation.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../fixtures/base';
+
+/**
+ * Critical flow: Login page renders, and an authenticated user can navigate
+ * the dashboard via the sidebar.
+ */
+
+test.describe('Login page', () => {
+  // The login page is the one place we do NOT want a seeded session.
+  test.use({ authenticated: false });
+
+  test('renders OAuth login options', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByRole('heading', { name: /welcome back/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /continue with google/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /continue with github/i })).toBeVisible();
+  });
+});
+
+test.describe('Dashboard navigation', () => {
+  test('lands on the home dashboard', async ({ page }) => {
+    await page.goto('/');
+
+    // Home hero heading is composed from i18n fragments -> "Automate your Payroll ...".
+    await expect(page.getByRole('heading', { name: /automate your/i })).toBeVisible();
+  });
+
+  test('navigates between sections via the sidebar', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('link', { name: 'Employees' }).click();
+    await expect(page).toHaveURL(/\/employee$/);
+
+    await page.getByRole('link', { name: 'Payroll', exact: true }).click();
+    await expect(page).toHaveURL(/\/payroll$/);
+
+    await page.getByRole('link', { name: 'History' }).click();
+    await expect(page).toHaveURL(/\/transactions$/);
+  });
+
+  test('home CTA routes to payroll', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: /manage payroll/i }).click();
+    await expect(page).toHaveURL(/\/payroll$/);
+  });
+});

--- a/frontend/e2e/tests/payroll.spec.ts
+++ b/frontend/e2e/tests/payroll.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '../fixtures/base';
+
+/**
+ * Critical flow: Payroll scheduler -> Create schedule (wizard) -> Confirm.
+ */
+
+test.describe('Payroll scheduler', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/payroll');
+  });
+
+  test('renders the payroll setup form', async ({ page }) => {
+    await expect(page.locator('#employeeName')).toBeVisible();
+    await expect(page.locator('#amount')).toBeVisible();
+    await expect(page.locator('#frequency')).toBeVisible();
+  });
+
+  test('fills the inline payroll form', async ({ page }) => {
+    await page.locator('#employeeName').fill('Satoshi Nakamoto');
+    await page.locator('#amount').fill('1500');
+    await page.locator('#frequency').selectOption('monthly');
+
+    await expect(page.locator('#employeeName')).toHaveValue('Satoshi Nakamoto');
+    await expect(page.locator('#amount')).toHaveValue('1500');
+    await expect(page.locator('#frequency')).toHaveValue('monthly');
+  });
+
+  test('walks the scheduling wizard through to the confirm step', async ({ page }) => {
+    await page.getByRole('button', { name: /open scheduling wizard/i }).click();
+
+    // Step 1
+    await expect(page.getByRole('heading', { name: /set schedule/i })).toBeVisible();
+    await page.getByRole('button', { name: /continue/i }).click();
+
+    // Step 2
+    await expect(page.getByRole('heading', { name: /currency preferences/i })).toBeVisible();
+    await page.getByRole('button', { name: /continue/i }).click();
+
+    // Step 3: Preview & Confirm
+    await expect(page.getByRole('heading', { name: /preview & confirm/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /confirm schedule/i })).toBeVisible();
+  });
+});

--- a/frontend/e2e/tests/transactions.spec.ts
+++ b/frontend/e2e/tests/transactions.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '../fixtures/base';
+
+/**
+ * Critical flow: Transaction history display and filtering.
+ */
+
+test.describe('Transaction history', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/transactions');
+  });
+
+  test('renders the transaction history view', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /transaction history/i })).toBeVisible();
+    // Filters (including the search box) are collapsed behind a toggle.
+    await page.getByRole('button', { name: /filters/i }).click();
+    await expect(page.getByPlaceholder(/search tx hash/i)).toBeVisible();
+  });
+
+  test('exposes status filter options', async ({ page }) => {
+    await page.getByRole('button', { name: /filters/i }).click();
+
+    const statusFilter = page.locator('select', {
+      has: page.locator('option', { hasText: 'Confirmed' }),
+    });
+    await expect(statusFilter).toBeVisible();
+
+    await statusFilter.selectOption('confirmed');
+    await expect(statusFilter).toHaveValue('confirmed');
+  });
+
+  test('accepts a search query', async ({ page }) => {
+    await page.getByRole('button', { name: /filters/i }).click();
+
+    const search = page.getByPlaceholder(/search tx hash/i);
+    await search.fill('abc123');
+    await expect(search).toHaveValue('abc123');
+  });
+});

--- a/frontend/e2e/tests/wallet.spec.ts
+++ b/frontend/e2e/tests/wallet.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '../fixtures/base';
+
+/**
+ * Critical flow: Wallet connection entry point.
+ *
+ * We can't drive a real browser-extension wallet in CI, so this validates that
+ * the connect action is reachable from the dashboard top bar and opens the
+ * Stellar Wallets Kit selection modal.
+ */
+
+test.describe('Wallet connection', () => {
+  // The connect button only shows when there is no active session, so run these
+  // without a seeded auth token.
+  test.use({ authenticated: false });
+
+  test('exposes the connect action on the dashboard', async ({ page }) => {
+    await page.goto('/');
+
+    const connect = page.locator('#tour-connect');
+    await expect(connect).toBeVisible();
+    await expect(connect).toContainText(/connect/i);
+    await expect(connect).toBeEnabled();
+  });
+
+  test('opens the wallet selection modal', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('#tour-connect').click();
+
+    // The Stellar Wallets Kit mounts its selection UI as a custom element whose
+    // visible content lives in shadow DOM (the host itself has no layout box).
+    // Assert the modal opened via its `showmodal` attribute, and that the title
+    // it renders is visible (Playwright pierces the open shadow root for text).
+    await expect(page.locator('stellar-wallets-modal[showmodal]')).toBeAttached();
+    await expect(page.getByText(/connect to payd/i)).toBeVisible();
+  });
+});

--- a/frontend/e2e/tsconfig.json
+++ b/frontend/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -38,5 +38,13 @@ export default tseslint.config(
     rules: {
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
+  },
+  {
+    // Playwright E2E tests: the fixture `use()` callback collides with React's
+    // `use` hook name, so the React-specific rules don't apply here.
+    files: ['e2e/**/*.ts'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+    },
   }
 );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.61.1",
         "@types/crypto-js": "^4.2.2",
         "@types/jest": "^30.0.0",
         "@types/lodash": "^4.17.21",
@@ -1850,6 +1851,22 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -10334,6 +10351,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,11 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "format": "prettier . --write"
+    "format": "prettier . --write",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report"
   },
   "workspaces": [
     "packages/*"
@@ -54,6 +58,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.61.1",
     "@types/crypto-js": "^4.2.2",
     "@types/jest": "^30.0.0",
     "@types/lodash": "^4.17.21",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for PayD frontend E2E tests.
+ *
+ * Tests run against the Vite dev server (started automatically via `webServer`)
+ * and mock all outbound network traffic (Stellar Horizon, Soroban RPC, backend
+ * API) so no real network calls or testnet transactions are required.
+ *
+ * See ./e2e/README.md for details.
+ */
+
+const PORT = Number(process.env.E2E_PORT ?? 5173);
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  // Run tests within each file in parallel.
+  fullyParallel: true,
+  // Fail the build on CI if test.only was left in the source.
+  forbidOnly: !!process.env.CI,
+  // Retry flaky tests on CI only.
+  retries: process.env.CI ? 2 : 0,
+  // Limit workers on CI for stability.
+  workers: process.env.CI ? 2 : undefined,
+  // HTML report for humans, plus a compact line reporter for the terminal/CI logs.
+  reporter: [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  // Desktop browsers only for the initial setup (mobile is out of scope).
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+
+  // Start the Vite dev server before running tests.
+  webServer: {
+    command: `npm run dev -- --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/frontend/src/providers/WalletProvider.tsx
+++ b/frontend/src/providers/WalletProvider.tsx
@@ -35,7 +35,16 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const { t } = useTranslation();
   const { notify, notifySuccess, notifyError } = useNotification();
 
-  const network = (import.meta.env.VITE_STELLAR_NETWORK || 'TESTNET') as WalletNetwork;
+  // `vite.config.ts` sets `envPrefix: 'PUBLIC_'`, so `VITE_`-prefixed vars are
+  // not exposed; read `PUBLIC_STELLAR_NETWORK` like the rest of the app does.
+  // Map the network name (e.g. "TESTNET") to the passphrase the kit expects,
+  // falling back to TESTNET so an unset/unknown value never crashes the app.
+  const networkName = (
+    (import.meta.env.PUBLIC_STELLAR_NETWORK as string | undefined) ||
+    (import.meta.env.VITE_STELLAR_NETWORK as string | undefined) ||
+    'TESTNET'
+  ).toUpperCase();
+  const network = WalletNetwork[networkName as keyof typeof WalletNetwork] ?? WalletNetwork.TESTNET;
 
   useEffect(() => {
     setWalletExtensionAvailable(hasAnyWalletExtension());

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -18,5 +18,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## What

Adds end-to-end testing infrastructure with **Playwright** for the frontend, covering the critical user flows called out in the issue. All outbound network traffic (Stellar Horizon, Soroban RPC, backend API) is mocked, so tests run offline with **no real testnet transactions** and a **seeded auth session** (no real OAuth login).

Closes #427

## Changes

**E2E infrastructure (`frontend/e2e/`)**
- `playwright.config.ts` — runs on Chromium + Firefox (desktop), auto-starts the Vite dev server via `webServer`, HTML + list reporters, traces/screenshots/videos retained on failure, retries on CI.
- `e2e/fixtures/base.ts` — extended `test` that auto-seeds auth and mocks the network; opt out per file with `test.use({ authenticated: false })` / `{ mockNetwork: false }`.
- `e2e/mocks/` — canned Horizon / Soroban RPC / backend responses, endpoint-specific shapes, seeded auth state, and a `mockRoute` helper for per-test overrides.
- `e2e/tsconfig.json`, eslint override, `.gitignore` entries for reports.

**Critical flows covered (`e2e/tests/`)**
1. **Login → Dashboard** — OAuth login options render; authenticated dashboard + sidebar navigation.
2. **Employees** — directory → add employee → required-field validation → valid entry.
3. **Payroll** — setup form + scheduling wizard walked through to the **confirm** step.
4. **Wallet connection** — connect entry point opens the Stellar Wallets Kit selection modal.
5. **Transaction history** — display + status/search filtering.

**Scripts** — `test:e2e`, `test:e2e:ui`, `test:e2e:headed`, `test:e2e:report`.

**CI (`.github/workflows/e2e.yml`)** — runs the suite on PRs touching `frontend/**` and via manual dispatch; uploads the HTML report and failure artifacts (traces, videos, screenshots).

## Prerequisite bug fix

While standing up the suite, the tests immediately caught a **blank-screen crash on app load**: `WalletProvider` read `import.meta.env.VITE_STELLAR_NETWORK`, but `vite.config.ts` sets `envPrefix: 'PUBLIC_'`, so `VITE_`-prefixed vars are never exposed. It always fell back to the literal string `'TESTNET'`, which the Stellar Wallets Kit rejects (the enum value is the network passphrase), throwing `Wallet network "TESTNET" is not supported` during render and blanking the whole app.

The fix reads `PUBLIC_STELLAR_NETWORK` (consistent with the rest of the app), maps the network name to the `WalletNetwork` enum, and falls back to `TESTNET` so an unset/unknown value never crashes the app.

## Acceptance criteria

- [x] `npx playwright install` works from `frontend/`
- [x] `npm run test:e2e` runs all E2E tests headlessly
- [x] At least 5 critical user flows covered
- [x] Stellar Horizon / RPC / API responses mocked (no real network calls)
- [x] Auth state seeded (no real login)
- [x] HTML test reports generated
- [x] CI workflow runs E2E on PRs (manual dispatch + frontend path trigger)

## Test results

All **32 tests pass** across Chromium and Firefox locally.

## How to run

```bash
cd frontend
npx playwright install
npm run test:e2e        # headless
npm run test:e2e:ui     # interactive
```
