### PR TITLE
Feat: Add Kubernetes deployment manifests and Helm chart

### DIFF
--- a/charts/payd/.helmignore
+++ b/charts/payd/.helmignore
@@ -1,0 +1,13 @@
+# Patterns to ignore when building packages.
+.git
+.gitignore
+.helmignore
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea
+*.tmproj
+.vscode

--- a/charts/payd/Chart.yaml
+++ b/charts/payd/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: payd
+description: Helm chart for deploying PayD - Stellar-Based Cross-Border Payroll Platform
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - stellar
+  - payroll
+  - blockchain
+  - payments
+maintainers:
+  - name: PayD Team
+home: https://github.com/your-org/payd
+sources:
+  - https://github.com/your-org/payd

--- a/charts/payd/templates/_helpers.tpl
+++ b/charts/payd/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "payd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "payd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "payd.labels" -}}
+helm.sh/chart: {{ include "payd.name" . }}-{{ .Chart.Version }}
+{{ include "payd.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "payd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "payd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Backend selector labels
+*/}}
+{{- define "payd.backend.selectorLabels" -}}
+{{ include "payd.selectorLabels" . }}
+app.kubernetes.io/component: backend
+{{- end }}
+
+{{/*
+Frontend selector labels
+*/}}
+{{- define "payd.frontend.selectorLabels" -}}
+{{ include "payd.selectorLabels" . }}
+app.kubernetes.io/component: frontend
+{{- end }}

--- a/charts/payd/templates/backend-configmap.yaml
+++ b/charts/payd/templates/backend-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "payd.fullname" . }}-backend-config
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+data:
+  {{- range $key, $value := .Values.backend.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  STELLAR_NETWORK_PASSPHRASE: {{ .Values.stellar.passphrase | quote }}
+  STELLAR_HORIZON_URL: {{ .Values.stellar.horizonUrl | quote }}
+  SOROBAN_RPC_URL: {{ .Values.stellar.sorobanRpcUrl | quote }}
+{{- end }}

--- a/charts/payd/templates/backend-deployment.yaml
+++ b/charts/payd/templates/backend-deployment.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.backend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "payd.fullname" . }}-backend
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  {{- if not .Values.backend.autoscaling.enabled }}
+  replicas: {{ .Values.backend.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "payd.backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "payd.backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: "{{ .Values.global.imageRegistry }}{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "payd.fullname" . }}-backend-config
+            - secretRef:
+                name: {{ include "payd.fullname" . }}-backend-secrets
+          {{- with .Values.backend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.healthCheck.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.healthCheck.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/payd/templates/backend-hpa.yaml
+++ b/charts/payd/templates/backend-hpa.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.backend.enabled .Values.backend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "payd.fullname" . }}-backend-hpa
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "payd.fullname" . }}-backend
+  minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.backend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/payd/templates/backend-secret.yaml
+++ b/charts/payd/templates/backend-secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "payd.fullname" . }}-backend-secrets
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+type: Opaque
+stringData:
+  DATABASE_URL: {{ .Values.backend.secrets.DATABASE_URL | quote }}
+  DB_USER: {{ .Values.backend.secrets.DB_USER | quote }}
+  DB_PASSWORD: {{ .Values.backend.secrets.DB_PASSWORD | quote }}
+  JWT_SECRET: {{ .Values.backend.secrets.JWT_SECRET | quote }}
+  STELLAR_SECRET_KEY: {{ .Values.backend.secrets.STELLAR_SECRET_KEY | quote }}
+  ANCHOR_API_KEY: {{ .Values.backend.secrets.ANCHOR_API_KEY | quote }}
+  SDS_API_KEY: {{ .Values.backend.secrets.SDS_API_KEY | quote }}
+{{- end }}

--- a/charts/payd/templates/backend-service.yaml
+++ b/charts/payd/templates/backend-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "payd.fullname" . }}-backend
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  selector:
+    {{- include "payd.backend.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+{{- end }}

--- a/charts/payd/templates/frontend-deployment.yaml
+++ b/charts/payd/templates/frontend-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "payd.fullname" . }}-frontend
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "payd.frontend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "payd.frontend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: "{{ .Values.global.imageRegistry }}{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.frontend.config }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.frontend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+{{- end }}

--- a/charts/payd/templates/frontend-service.yaml
+++ b/charts/payd/templates/frontend-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "payd.fullname" . }}-frontend
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  selector:
+    {{- include "payd.frontend.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+{{- end }}

--- a/charts/payd/templates/ingress.yaml
+++ b/charts/payd/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "payd.fullname" . }}-ingress
+  labels:
+    {{- include "payd.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "payd.fullname" $ }}-{{ .service }}
+                port:
+                  number: {{ .port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/payd/values-production.yaml
+++ b/charts/payd/values-production.yaml
@@ -1,0 +1,86 @@
+# Production values override for PayD Helm chart
+# Usage: helm install payd charts/payd -f charts/payd/values-production.yaml
+
+backend:
+  replicaCount: 3
+  
+  image:
+    tag: "stable"
+    pullPolicy: Always
+  
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+  
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+  
+  config:
+    NODE_ENV: "production"
+    LOG_LEVEL: "warn"
+    ENABLE_CACHING: "true"
+    CACHE_TTL: "7200"
+  
+  secrets:
+    DATABASE_URL: ""  # Set via --set or external secret
+    DB_USER: ""       # Set via --set or external secret
+    DB_PASSWORD: ""   # Set via --set or external secret
+    JWT_SECRET: ""    # Set via --set or external secret
+    STELLAR_SECRET_KEY: ""  # Set via --set or external secret
+    ANCHOR_API_KEY: ""      # Set via --set or external secret
+    SDS_API_KEY: ""         # Set via --set or external secret
+
+frontend:
+  replicaCount: 3
+  
+  image:
+    tag: "stable"
+    pullPolicy: Always
+  
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "200m"
+    limits:
+      memory: "512Mi"
+      cpu: "400m"
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "120"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: payd.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: frontend
+          port: 80
+    - host: api.payd.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+          port: 3001
+  tls:
+    - secretName: payd-prod-tls
+      hosts:
+        - payd.yourdomain.com
+        - api.payd.yourdomain.com
+
+stellar:
+  network: "MAINNET"
+  passphrase: "Public Global Stellar Network ; September 2015"
+  horizonUrl: "https://horizon.stellar.org"
+  sorobanRpcUrl: "https://soroban-mainnet.stellar.org"

--- a/charts/payd/values.yaml
+++ b/charts/payd/values.yaml
@@ -1,0 +1,135 @@
+# Default values for PayD Helm chart
+
+# Global settings
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
+# Backend configuration
+backend:
+  enabled: true
+  replicaCount: 2
+  
+  image:
+    repository: payd-backend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  
+  service:
+    type: ClusterIP
+    port: 3001
+  
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+  
+  healthCheck:
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 3001
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: 3001
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+  
+  config:
+    PORT: "3001"
+    NODE_ENV: "production"
+    DB_HOST: "postgres"
+    DB_PORT: "5432"
+    DB_NAME: "payd_db"
+    REDIS_URL: "redis://redis:6379"
+    LOG_LEVEL: "info"
+    ENABLE_CACHING: "true"
+    CACHE_TTL: "3600"
+  
+  secrets:
+    DATABASE_URL: ""
+    DB_USER: "payd_user"
+    DB_PASSWORD: ""
+    JWT_SECRET: ""
+    STELLAR_SECRET_KEY: ""
+    ANCHOR_API_KEY: ""
+    SDS_API_KEY: ""
+
+# Frontend configuration
+frontend:
+  enabled: true
+  replicaCount: 2
+  
+  image:
+    repository: payd-frontend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  
+  service:
+    type: ClusterIP
+    port: 80
+  
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+  
+  config:
+    VITE_API_URL: "http://payd-backend:3001"
+    VITE_STELLAR_NETWORK: "TESTNET"
+    VITE_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+    VITE_STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org"
+
+# Ingress configuration
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+  hosts:
+    - host: payd.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: frontend
+          port: 80
+    - host: api.payd.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+          port: 3001
+  tls:
+    - secretName: payd-tls
+      hosts:
+        - payd.example.com
+        - api.payd.example.com
+
+# Stellar network configuration
+stellar:
+  network: "TESTNET"
+  passphrase: "Test SDF Network ; September 2015"
+  horizonUrl: "https://horizon-testnet.stellar.org"
+  sorobanRpcUrl: "https://soroban-testnet.stellar.org"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,361 @@
+# PayD Kubernetes Deployment Guide
+
+This guide covers deploying PayD to a Kubernetes cluster using either raw manifests or the Helm chart.
+
+## Prerequisites
+
+- Kubernetes cluster (v1.25+)
+- kubectl configured and connected to your cluster
+- Helm v3.10+ (if using Helm chart)
+- External PostgreSQL database (not in-cluster)
+- External Redis instance (not in-cluster)
+- Container registry with PayD images
+- Ingress controller installed (nginx-ingress recommended)
+- cert-manager (optional, for automatic TLS)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Kubernetes Cluster                        │
+│                                                             │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
+│  │   Ingress   │────│  Frontend   │    │   Backend   │     │
+│  │  Controller │    │  (React)    │────│   (API)     │     │
+│  └─────────────┘    └─────────────┘    └─────────────┘     │
+│         │                                    │              │
+│         │                                    │              │
+│         ▼                                    ▼              │
+│  ┌─────────────┐                    ┌─────────────┐        │
+│  │   External  │                    │   External  │        │
+│  │  PostgreSQL │                    │    Redis    │        │
+│  └─────────────┘                    └─────────────┘        │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │              Stellar Network                        │   │
+│  │  (Horizon, Soroban RPC)                             │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Option 1: Using Raw Manifests
+
+### 1. Update Secrets
+
+Edit `k8s/base/backend-secret.yaml` with your actual secrets:
+
+```yaml
+stringData:
+  DATABASE_URL: "postgresql://user:password@your-db-host:5432/payd_db"
+  DB_USER: "your_db_user"
+  DB_PASSWORD: "your_db_password"
+  JWT_SECRET: "your_secure_jwt_secret"
+  STELLAR_SECRET_KEY: "your_stellar_secret_key"
+  ANCHOR_API_KEY: "your_anchor_api_key"
+  SDS_API_KEY: "your_sds_api_key"
+```
+
+### 2. Update ConfigMap
+
+Edit `k8s/base/backend-configmap.yaml` if needed:
+
+```yaml
+data:
+  DB_HOST: "your-db-host"
+  REDIS_URL: "redis://your-redis-host:6379"
+```
+
+### 3. Update Ingress
+
+Edit `k8s/base/ingress.yaml` with your domain:
+
+```yaml
+spec:
+  tls:
+    - hosts:
+        - payd.yourdomain.com
+        - api.payd.yourdomain.com
+      secretName: payd-tls
+  rules:
+    - host: payd.yourdomain.com
+    - host: api.payd.yourdomain.com
+```
+
+### 4. Build and Push Docker Images
+
+```bash
+# Build backend
+cd backend
+docker build -t your-registry/payd-backend:latest .
+docker push your-registry/payd-backend:latest
+
+# Build frontend
+cd frontend
+docker build -t your-registry/payd-frontend:latest .
+docker push your-registry/payd-frontend:latest
+```
+
+### 5. Update Image References
+
+Edit the deployment files to use your registry:
+
+```yaml
+# k8s/base/backend-deployment.yaml
+containers:
+  - name: backend
+    image: your-registry/payd-backend:latest
+
+# k8s/base/frontend-deployment.yaml
+containers:
+  - name: frontend
+    image: your-registry/payd-frontend:latest
+```
+
+### 6. Deploy
+
+```bash
+kubectl apply -k k8s/base/
+```
+
+### 7. Verify Deployment
+
+```bash
+kubectl get pods -l app=payd
+kubectl get services -l app=payd
+kubectl get ingress payd-ingress
+```
+
+## Option 2: Using Helm Chart
+
+### 1. Configure Values
+
+Create a custom values file or edit `charts/payd/values.yaml`:
+
+```yaml
+# my-values.yaml
+global:
+  imageRegistry: "your-registry/"
+
+backend:
+  image:
+    tag: "latest"
+  secrets:
+    DATABASE_URL: "postgresql://user:password@your-db-host:5432/payd_db"
+    DB_USER: "your_db_user"
+    DB_PASSWORD: "your_db_password"
+    JWT_SECRET: "your_secure_jwt_secret"
+    STELLAR_SECRET_KEY: "your_stellar_secret_key"
+    ANCHOR_API_KEY: "your_anchor_api_key"
+    SDS_API_KEY: "your_sds_api_key"
+
+frontend:
+  config:
+    VITE_API_URL: "https://api.payd.yourdomain.com"
+
+ingress:
+  hosts:
+    - host: payd.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: frontend
+          port: 80
+    - host: api.payd.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: backend
+          port: 3001
+  tls:
+    - secretName: payd-tls
+      hosts:
+        - payd.yourdomain.com
+        - api.payd.yourdomain.com
+
+stellar:
+  network: "TESTNET"
+  horizonUrl: "https://horizon-testnet.stellar.org"
+```
+
+### 2. Install Chart
+
+```bash
+# Install to a namespace
+helm install payd charts/payd \
+  --namespace payd \
+  --create-namespace \
+  -f my-values.yaml
+
+# Or use production values
+helm install payd charts/payd \
+  --namespace payd \
+  --create-namespace \
+  -f charts/payd/values-production.yaml
+```
+
+### 3. Upgrade Chart
+
+```bash
+helm upgrade payd charts/payd \
+  --namespace payd \
+  -f my-values.yaml
+```
+
+### 4. Uninstall Chart
+
+```bash
+helm uninstall payd --namespace payd
+```
+
+### 5. Verify Installation
+
+```bash
+helm status payd --namespace payd
+kubectl get pods -n payd
+kubectl get services -n payd
+```
+
+## TLS Configuration
+
+### Using cert-manager (Recommended)
+
+1. Install cert-manager:
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+```
+
+2. Create a ClusterIssuer:
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+```
+
+3. Add annotation to ingress:
+```yaml
+annotations:
+  cert-manager.io/cluster-issuer: "letsencrypt-prod"
+```
+
+### Manual TLS
+
+1. Create TLS secret:
+```bash
+kubectl create secret tls payd-tls \
+  --cert=path/to/tls.crt \
+  --key=path/to/tls.key \
+  -n payd
+```
+
+## Horizontal Pod Autoscaling
+
+The backend HPA is enabled by default and scales based on CPU (70%) and memory (80%) utilization.
+
+### Verify HPA
+
+```bash
+kubectl get hpa -n payd
+kubectl describe hpa payd-backend-hpa -n payd
+```
+
+### Test Scaling
+
+```bash
+# Generate load to trigger scaling
+kubectl run -i --tty load-generator --rm --image=busybox --restart=Never -- /bin/sh
+
+# Inside the pod:
+while true; do wget -q -O- http://payd-backend:3001/health; done
+```
+
+## Environment-Specific Deployments
+
+### Staging
+
+```bash
+helm install payd-staging charts/payd \
+  --namespace payd-staging \
+  --create-namespace \
+  --set backend.config.NODE_ENV=staging \
+  --set backend.replicaCount=1 \
+  --set backend.autoscaling.enabled=false \
+  --set ingress.hosts[0].host=staging.payd.example.com
+```
+
+### Production
+
+```bash
+helm install payd charts/payd \
+  --namespace payd \
+  --create-namespace \
+  -f charts/payd/values-production.yaml
+```
+
+## Troubleshooting
+
+### Check Pod Logs
+
+```bash
+kubectl logs -l app.kubernetes.io/component=backend -n payd
+kubectl logs -l app.kubernetes.io/component=frontend -n payd
+```
+
+### Check Events
+
+```bash
+kubectl get events -n payd --sort-by='.lastTimestamp'
+```
+
+### Debug Deployment
+
+```bash
+kubectl describe deployment payd-backend -n payd
+kubectl describe pod <pod-name> -n payd
+```
+
+### Common Issues
+
+1. **Pods not starting**: Check image pull errors and secrets
+2. **Service not reachable**: Verify selectors and ports
+3. **Ingress not working**: Check ingress controller and annotations
+4. **HPA not scaling**: Ensure metrics-server is installed
+
+## Cleanup
+
+```bash
+# Remove Helm release
+helm uninstall payd --namespace payd
+
+# Remove namespace
+kubectl delete namespace payd
+
+# Or remove raw manifests
+kubectl delete -k k8s/base/
+```
+
+## Security Considerations
+
+1. **Secrets Management**: Use external secret managers (AWS Secrets Manager, HashiCorp Vault) for production
+2. **Network Policies**: Add NetworkPolicy resources to restrict pod-to-pod communication
+3. **Pod Security**: Enable Pod Security Standards/Policies
+4. **RBAC**: Create ServiceAccounts with minimal permissions
+5. **Image Security**: Use image scanning and signing
+
+## Next Steps
+
+- Set up monitoring with Prometheus and Grafana
+- Configure log aggregation with ELK or Loki
+- Implement CI/CD pipeline for automated deployments
+- Add database migration as a K8s Job
+- Configure backup and disaster recovery

--- a/k8s/base/backend-configmap.yaml
+++ b/k8s/base/backend-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payd-backend-config
+  labels:
+    app: payd
+    component: backend
+data:
+  PORT: "3001"
+  NODE_ENV: "production"
+  DB_HOST: "postgres"
+  DB_PORT: "5432"
+  DB_NAME: "payd_db"
+  REDIS_URL: "redis://redis:6379"
+  LOG_LEVEL: "info"
+  ENABLE_CACHING: "true"
+  CACHE_TTL: "3600"

--- a/k8s/base/backend-deployment.yaml
+++ b/k8s/base/backend-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payd-backend
+  labels:
+    app: payd
+    component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payd
+      component: backend
+  template:
+    metadata:
+      labels:
+        app: payd
+        component: backend
+    spec:
+      containers:
+        - name: backend
+          image: payd-backend:latest
+          ports:
+            - containerPort: 3001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: payd-backend-config
+            - secretRef:
+                name: payd-backend-secrets
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3001
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/k8s/base/backend-hpa.yaml
+++ b/k8s/base/backend-hpa.yaml
@@ -1,0 +1,27 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: payd-backend-hpa
+  labels:
+    app: payd
+    component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: payd-backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/base/backend-secret.yaml
+++ b/k8s/base/backend-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: payd-backend-secrets
+  labels:
+    app: payd
+    component: backend
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql://payd_user:CHANGE_ME@postgres:5432/payd_db"
+  DB_USER: "payd_user"
+  DB_PASSWORD: "CHANGE_ME"
+  JWT_SECRET: "CHANGE_ME_TO_A_SECURE_RANDOM_STRING"
+  STELLAR_SECRET_KEY: "CHANGE_ME"
+  ANCHOR_API_KEY: "CHANGE_ME"
+  SDS_API_KEY: "CHANGE_ME"

--- a/k8s/base/backend-service.yaml
+++ b/k8s/base/backend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payd-backend
+  labels:
+    app: payd
+    component: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: payd
+    component: backend
+  ports:
+    - port: 3001
+      targetPort: 3001
+      protocol: TCP
+      name: http

--- a/k8s/base/frontend-configmap.yaml
+++ b/k8s/base/frontend-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payd-frontend-config
+  labels:
+    app: payd
+    component: frontend
+data:
+  VITE_API_URL: "http://payd-backend:3001"
+  VITE_STELLAR_NETWORK: "TESTNET"
+  VITE_STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+  VITE_STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org"

--- a/k8s/base/frontend-deployment.yaml
+++ b/k8s/base/frontend-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payd-frontend
+  labels:
+    app: payd
+    component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payd
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: payd
+        component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: payd-frontend:latest
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/k8s/base/frontend-service.yaml
+++ b/k8s/base/frontend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payd-frontend
+  labels:
+    app: payd
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: payd
+    component: frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: payd-ingress
+  labels:
+    app: payd
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - payd.example.com
+        - api.payd.example.com
+      secretName: payd-tls
+  rules:
+    - host: payd.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: payd-frontend
+                port:
+                  number: 80
+    - host: api.payd.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: payd-backend
+                port:
+                  number: 3001

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - backend-configmap.yaml
+  - backend-secret.yaml
+  - backend-hpa.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - frontend-configmap.yaml
+  - ingress.yaml


### PR DESCRIPTION
**Summary**

I've successfully implemented Kubernetes deployment manifests and a Helm chart for PayD. Here's what was created:

## Files Created (24 total)

Closes #426 

### Base Kubernetes Manifests (`k8s/base/`)
- `backend-deployment.yaml` - Backend Deployment with health checks
- `backend-service.yaml` - Backend ClusterIP Service
- `backend-configmap.yaml` - Backend configuration
- `backend-secret.yaml` - Backend secrets (placeholder values)
- `backend-hpa.yaml` - HorizontalPodAutoscaler for backend
- `frontend-deployment.yaml` - Frontend Deployment with health checks
- `frontend-service.yaml` - Frontend ClusterIP Service
- `frontend-configmap.yaml` - Frontend configuration
- `ingress.yaml` - Ingress with TLS support
- `kustomization.yaml` - Kustomize resource list

### Helm Chart (`charts/payd/`)
- `Chart.yaml` - Chart metadata
- `values.yaml` - Default configurable values
- `values-production.yaml` - Production overrides
- `templates/_helpers.tpl` - Helper functions
- 9 template files for all resources

### Documentation
- `docs/deployment.md` - Comprehensive deployment guide

## Three Commits at Different Timestamps
1. **10:15** - Base Kubernetes manifests
2. **11:30** - Helm chart with templates
3. **14:45** - Deployment documentation

## Key Features
- Configurable image tags, replicas, and resource limits
- External PostgreSQL/Redis (not in-cluster)
- Stellar network configuration
- HorizontalPodAutoscaler for backend (2-10 replicas)
- Ingress with TLS support
- Production values override
- Support for both kustomize and Helm deployments