### PR TITLE
Mainnet op/branch

### DIFF
--- a/backend/src/controllers/webhook.controller.ts
+++ b/backend/src/controllers/webhook.controller.ts
@@ -12,7 +12,9 @@ export class WebhookController {
   static async subscribe(req: Request, res: Response) {
     try {
       const validatedData = subscribeSchema.parse(req.body);
+      const organizationId = req.tenantId!;
       const subscription = await WebhookService.subscribe(
+        organizationId,
         validatedData.url,
         validatedData.secret,
         validatedData.events
@@ -28,13 +30,15 @@ export class WebhookController {
   }
 
   static listSubscriptions(req: Request, res: Response) {
-    const subscriptions = WebhookService.listSubscriptions();
+    const organizationId = req.tenantId!;
+    const subscriptions = WebhookService.listSubscriptions(organizationId);
     res.json(subscriptions);
   }
 
   static deleteSubscription(req: Request, res: Response) {
     const { id } = req.params;
-    const success = WebhookService.deleteSubscription(id as string);
+    const organizationId = req.tenantId!;
+    const success = WebhookService.deleteSubscription(id as string, organizationId);
     if (success) {
       res.status(204).send();
       return;
@@ -42,7 +46,6 @@ export class WebhookController {
     res.status(404).json({ error: 'Subscription not found' });
   }
 
-  // Debug endpoint to trigger a mock event
   static async triggerMockEvent(req: Request, res: Response) {
     const { event, payload } = req.body;
     await WebhookService.dispatch(

--- a/backend/src/routes/__tests__/webhook.routes.test.ts
+++ b/backend/src/routes/__tests__/webhook.routes.test.ts
@@ -1,0 +1,200 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import webhookRoutes from '../webhook.routes.js';
+import { WebhookService } from '../../services/webhook.service.js';
+
+const JWT_SECRET = 'test-secret';
+
+jest.mock('../../config/env.js', () => ({
+  config: { JWT_SECRET: 'test-secret' },
+}));
+
+jest.mock('../../config/database.js', () => ({
+  pool: {
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+    connect: jest.fn().mockResolvedValue({
+      query: jest.fn().mockResolvedValue({}),
+      release: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../../utils/logger.js', () => ({
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+function makeToken(payload: object): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
+}
+
+const tenantAToken = makeToken({
+  id: 1,
+  organizationId: 10,
+  email: 'admin@orgA.com',
+  role: 'EMPLOYER',
+});
+
+const tenantBToken = makeToken({
+  id: 2,
+  organizationId: 20,
+  email: 'admin@orgB.com',
+  role: 'EMPLOYER',
+});
+
+const app = express();
+app.use(express.json());
+app.use('/webhooks', webhookRoutes);
+
+describe('Webhook Routes - Auth and Tenant Isolation', () => {
+  beforeEach(async () => {
+    // Clear in-memory subscriptions by listing and deleting for both tenants
+    const subsA = WebhookService.listSubscriptions(10);
+    for (const s of subsA) WebhookService.deleteSubscription(s.id, 10);
+    const subsB = WebhookService.listSubscriptions(20);
+    for (const s of subsB) WebhookService.deleteSubscription(s.id, 20);
+  });
+
+  describe('Authentication required', () => {
+    it('rejects POST /subscribe with no token', async () => {
+      const res = await request(app)
+        .post('/webhooks/subscribe')
+        .send({ url: 'https://example.com/hook', secret: 'a'.repeat(16), events: ['*'] });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects GET /subscriptions with no token', async () => {
+      const res = await request(app).get('/webhooks/subscriptions');
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects DELETE /subscriptions/:id with no token', async () => {
+      const res = await request(app).delete('/webhooks/subscriptions/fake-id');
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects POST /test-trigger with no token', async () => {
+      const res = await request(app)
+        .post('/webhooks/test-trigger')
+        .send({ event: 'payment.completed' });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects requests with an invalid token', async () => {
+      const res = await request(app)
+        .get('/webhooks/subscriptions')
+        .set('Authorization', 'Bearer invalid-token');
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('Tenant isolation', () => {
+    it('scopes subscriptions to the creating tenant', async () => {
+      const resA = await request(app)
+        .post('/webhooks/subscribe')
+        .set('Authorization', `Bearer ${tenantAToken}`)
+        .send({ url: 'https://orgA.example.com/hook', secret: 'a'.repeat(16), events: ['*'] });
+
+      expect(resA.status).toBe(201);
+      expect(resA.body.organizationId).toBe(10);
+
+      const listA = await request(app)
+        .get('/webhooks/subscriptions')
+        .set('Authorization', `Bearer ${tenantAToken}`);
+
+      expect(listA.status).toBe(200);
+      expect(listA.body).toHaveLength(1);
+      expect(listA.body[0].organizationId).toBe(10);
+    });
+
+    it('tenant B cannot see tenant A subscriptions', async () => {
+      await request(app)
+        .post('/webhooks/subscribe')
+        .set('Authorization', `Bearer ${tenantAToken}`)
+        .send({ url: 'https://orgA.example.com/hook', secret: 'a'.repeat(16), events: ['*'] });
+
+      const listB = await request(app)
+        .get('/webhooks/subscriptions')
+        .set('Authorization', `Bearer ${tenantBToken}`);
+
+      expect(listB.status).toBe(200);
+      expect(listB.body).toHaveLength(0);
+    });
+
+    it('tenant B cannot delete tenant A subscription by ID', async () => {
+      const createRes = await request(app)
+        .post('/webhooks/subscribe')
+        .set('Authorization', `Bearer ${tenantAToken}`)
+        .send({ url: 'https://orgA.example.com/hook', secret: 'a'.repeat(16), events: ['*'] });
+
+      const subId = createRes.body.id;
+
+      const deleteRes = await request(app)
+        .delete(`/webhooks/subscriptions/${subId}`)
+        .set('Authorization', `Bearer ${tenantBToken}`);
+
+      expect(deleteRes.status).toBe(404);
+
+      const listA = await request(app)
+        .get('/webhooks/subscriptions')
+        .set('Authorization', `Bearer ${tenantAToken}`);
+
+      expect(listA.body).toHaveLength(1);
+    });
+
+    it('tenant can delete their own subscription', async () => {
+      const createRes = await request(app)
+        .post('/webhooks/subscribe')
+        .set('Authorization', `Bearer ${tenantAToken}`)
+        .send({ url: 'https://orgA.example.com/hook', secret: 'a'.repeat(16), events: ['*'] });
+
+      const subId = createRes.body.id;
+
+      const deleteRes = await request(app)
+        .delete(`/webhooks/subscriptions/${subId}`)
+        .set('Authorization', `Bearer ${tenantAToken}`);
+
+      expect(deleteRes.status).toBe(204);
+
+      const listA = await request(app)
+        .get('/webhooks/subscriptions')
+        .set('Authorization', `Bearer ${tenantAToken}`);
+
+      expect(listA.body).toHaveLength(0);
+    });
+  });
+
+  describe('test-trigger production guard', () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('allows test-trigger in development', async () => {
+      process.env.NODE_ENV = 'development';
+
+      const res = await request(app)
+        .post('/webhooks/test-trigger')
+        .set('Authorization', `Bearer ${tenantAToken}`)
+        .send({ event: 'payment.completed', payload: { id: 'test' } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Mock event dispatched');
+    });
+
+    it('blocks test-trigger in production', async () => {
+      process.env.NODE_ENV = 'production';
+
+      const res = await request(app)
+        .post('/webhooks/test-trigger')
+        .set('Authorization', `Bearer ${tenantAToken}`)
+        .send({ event: 'payment.completed' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/backend/src/routes/webhook.routes.ts
+++ b/backend/src/routes/webhook.routes.ts
@@ -1,11 +1,28 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { WebhookController } from '../controllers/webhook.controller.js';
+import { authenticateJWT } from '../middlewares/auth.js';
+import { syncTenantFromUser } from '../middleware/tenantContext.js';
+import { strictTenantBoundary, logTenantAccess } from '../middleware/enhancedTenantIsolation.js';
 
 const router = Router();
+
+router.use(authenticateJWT);
+router.use(syncTenantFromUser);
+router.use(strictTenantBoundary);
+router.use(logTenantAccess);
 
 router.post('/subscribe', WebhookController.subscribe);
 router.get('/subscriptions', WebhookController.listSubscriptions);
 router.delete('/subscriptions/:id', WebhookController.deleteSubscription);
-router.post('/test-trigger', WebhookController.triggerMockEvent);
+
+const requireNonProduction = (req: Request, res: Response, next: NextFunction) => {
+  if (process.env.NODE_ENV === 'production') {
+    res.status(404).json({ error: 'Not Found' });
+    return;
+  }
+  next();
+};
+
+router.post('/test-trigger', requireNonProduction, WebhookController.triggerMockEvent);
 
 export default router;

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -6,29 +6,38 @@ export interface WebhookSubscription {
   url: string;
   secret: string;
   events: string[];
+  organizationId: number;
 }
 
 // In-memory storage for demonstration (in a real app, this would be a database)
 const subscriptions: WebhookSubscription[] = [];
 
 export class WebhookService {
-  static async subscribe(url: string, secret: string, events: string[]): Promise<WebhookSubscription> {
+  static async subscribe(
+    organizationId: number,
+    url: string,
+    secret: string,
+    events: string[]
+  ): Promise<WebhookSubscription> {
     const subscription: WebhookSubscription = {
       id: Math.random().toString(36).substring(2, 11),
       url,
       secret,
       events,
+      organizationId,
     };
     subscriptions.push(subscription);
     return subscription;
   }
 
-  static listSubscriptions(): WebhookSubscription[] {
-    return subscriptions;
+  static listSubscriptions(organizationId: number): WebhookSubscription[] {
+    return subscriptions.filter((s) => s.organizationId === organizationId);
   }
 
-  static deleteSubscription(id: string): boolean {
-    const index = subscriptions.findIndex((s) => s.id === id);
+  static deleteSubscription(id: string, organizationId: number): boolean {
+    const index = subscriptions.findIndex(
+      (s) => s.id === id && s.organizationId === organizationId
+    );
     if (index !== -1) {
       subscriptions.splice(index, 1);
       return true;


### PR DESCRIPTION

Closes #400 

## Summary

Webhook subscription routes (`POST /subscribe`, `GET /subscriptions`, `DELETE /subscriptions/:id`, `POST /test-trigger`) were mounted with no authentication or tenant isolation middleware. This allowed any unauthenticated caller to register webhook subscriptions (SSRF/data-exfiltration vector — the server POSTs event data to attacker-controlled URLs), enumerate or delete other tenants' subscriptions by ID, and fire mock events in production.

## Changes

**`backend/src/services/webhook.service.ts`**
- Added `organizationId` field to `WebhookSubscription` interface
- `subscribe()` now requires `organizationId` and stamps it on new subscriptions
- `listSubscriptions()` filters by `organizationId` — tenants only see their own
- `deleteSubscription()` verifies `organizationId` matches before deleting — cross-tenant delete returns `false`

**`backend/src/controllers/webhook.controller.ts`**
- `subscribe`, `listSubscriptions`, and `deleteSubscription` now read `req.tenantId` and pass it to the service layer

**`backend/src/routes/webhook.routes.ts`**
- Stacked `authenticateJWT`, `syncTenantFromUser`, `strictTenantBoundary`, and `logTenantAccess` middleware on all routes (matching `balanceRoutes.ts` pattern)
- `POST /test-trigger` is guarded by `requireNonProduction` — returns 404 when `NODE_ENV=production`

**`backend/src/routes/__tests__/webhook.routes.test.ts`** (new)
- 11 tests covering auth and tenant isolation

## Testing

```
npx jest src/routes/__tests__/webhook.routes.test.ts --no-coverage
```

**11 tests passing:**

| Test | Status |
|------|--------|
| `rejects POST /subscribe with no token` | PASS |
| `rejects GET /subscriptions with no token` | PASS |
| `rejects DELETE /subscriptions/:id with no token` | PASS |
| `rejects POST /test-trigger with no token` | PASS |
| `rejects requests with an invalid token` | PASS |
| `scopes subscriptions to the creating tenant` | PASS |
| `tenant B cannot see tenant A subscriptions` | PASS |
| `tenant B cannot delete tenant A subscription by ID` | PASS |
| `tenant can delete their own subscription` | PASS |
| `allows test-trigger in development` | PASS |
| `blocks test-trigger in production` | PASS |

## Tradeoffs

- **In-memory storage unchanged**: The webhook service uses in-memory storage (`subscriptions[]`). The tenant scoping is enforced at the service layer by filtering on `organizationId`. This is sufficient for the security fix; migrating to database-backed storage with RLS is a separate concern.
- **`requireNonProduction` guard vs admin-only**: Chose `NODE_ENV` guard over admin-role check because `test-trigger` is a debug endpoint with no legitimate use in production. Admin-only would still leave it reachable to compromised admin accounts.
- **No URL allowlisting**: The issue mentioned considering URL validation/allowlisting for SSRF reduction. This PR does not add URL allowlisting — the auth + tenant isolation stack already prevents unauthenticated subscription registration, which was the primary SSRF vector. URL allowlisting is a defense-in-depth measure that can follow separately.

## Out of Scope

- Redesigning the webhook delivery pipeline
- Database-backed webhook storage with RLS
- URL allowlisting / SSRF-specific defenses beyond auth gating
- Admin-role check on `test-trigger` (NODE_ENV guard chosen instead)
```
