### PR TITLE
fix(frontend): remove hardcoded employer secret key, sign via wallet

### DIFF
--- a/frontend/src/pages/PayrollScheduler.tsx
+++ b/frontend/src/pages/PayrollScheduler.tsx
@@ -5,7 +5,9 @@ import { useTransactionSimulation } from '../hooks/useTransactionSimulation';
 import { TransactionSimulationPanel } from '../components/TransactionSimulationPanel';
 import { useNotification } from '../hooks/useNotification';
 import { useSocket } from '../hooks/useSocket';
-import { createClaimableBalanceTransaction, generateWallet } from '../services/stellar';
+import { buildClaimableBalanceXdr, generateWallet } from '../services/stellar';
+import { useWallet } from '../hooks/useWallet';
+import { useWalletSigning } from '../hooks/useWalletSigning';
 import { useTranslation } from 'react-i18next';
 import { Card, Heading, Text, Button, Input, Select } from '@stellar/design-system';
 import { SchedulingWizard } from '../components/SchedulingWizard';
@@ -62,9 +64,6 @@ interface PendingClaim {
   status: string;
 }
 
-// Mock employer secret key for simulation purposes
-const MOCK_EMPLOYER_SECRET = 'SD3X5K7G7XV4K5V3M2G5QXH434M3VX6O5P3QVQO3L2PQSQQQQQQQQQQQ';
-
 const initialFormState: PayrollFormState = {
   employeeName: '',
   amount: '',
@@ -89,6 +88,7 @@ export default function PayrollScheduler() {
   const [nextRunDate, setNextRunDate] = useState<Date | null>(null);
   const [dbSchedules, setDbSchedules] = useState<ScheduleRecord[]>([]);
   const [isLoadingSchedules, setIsLoadingSchedules] = useState(false);
+  const [recipientPublicKey, setRecipientPublicKey] = useState<string | null>(null);
 
   const [pendingClaims, setPendingClaims] = useState<PendingClaim[]>(() => {
     const saved = localStorage.getItem('pending-claims');
@@ -115,6 +115,9 @@ export default function PayrollScheduler() {
     error: simulationProcessError,
     isSuccess: simulationPassed,
   } = useTransactionSimulation();
+
+  const { address, requireWallet } = useWallet();
+  const { sign } = useWalletSigning();
 
   useEffect(() => {
     const saved = loadSavedData();
@@ -209,76 +212,99 @@ export default function PayrollScheduler() {
       return;
     }
 
-    // Mock XDR for simulation demonstration
-    const mockXdr =
-      'AAAAAgAAAABmF8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    try {
+      await requireWallet(async () => {
+        // The employer's connected wallet is the source account funding the
+        // claimable balance; the employee's claimant address is generated
+        // once per schedule and reused for both simulation and broadcast so
+        // they refer to the same transaction.
+        const claimantPublicKey = recipientPublicKey ?? generateWallet().publicKey;
+        setRecipientPublicKey(claimantPublicKey);
 
-    await simulate({ envelopeXdr: mockXdr });
+        const xdr = await buildClaimableBalanceXdr({
+          sourceAddress: address!,
+          claimantPublicKey,
+          amount: String(formData.amount),
+          assetCode: 'USDC',
+        });
+
+        await simulate({ envelopeXdr: xdr });
+      });
+    } catch (err) {
+      console.error(err);
+      notifyError(
+        'Simulation failed',
+        err instanceof Error ? err.message : 'Unable to build the transaction for simulation.'
+      );
+    }
   };
 
   const handleBroadcast = async () => {
     setIsBroadcasting(true);
     try {
-      const mockRecipientPublicKey = generateWallet().publicKey;
+      await requireWallet(async () => {
+        const claimantPublicKey = recipientPublicKey ?? generateWallet().publicKey;
+        setRecipientPublicKey(claimantPublicKey);
 
-      // Integrate claimable balance logic from Issue #44
-      const result = createClaimableBalanceTransaction(
-        MOCK_EMPLOYER_SECRET,
-        mockRecipientPublicKey,
-        String(formData.amount),
-        'USDC'
-      );
-
-      if (!result.success) {
-        throw new Error('Failed to create claimable balance');
-      }
-
-      // Simulate a brief delay for network broadcast
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-
-      // Add to pending claims
-      const newClaim: PendingClaim = {
-        id: Math.random().toString(36).substr(2, 9),
-        employeeName: formData.employeeName,
-        amount: formData.amount,
-        dateScheduled: formData.startDate || new Date().toISOString().split('T')[0],
-        claimantPublicKey: mockRecipientPublicKey,
-        status: 'Pending Claim',
-      };
-
-      const updatedClaims = [...pendingClaims, newClaim];
-      setPendingClaims(updatedClaims);
-      localStorage.setItem('pending-claims', JSON.stringify(updatedClaims));
-
-      // Subscribe to updates for this new claim
-      subscribeToTransaction(newClaim.id);
-
-      notifySuccess(
-        'Broadcast successful!',
-        `Claimable balance created for ${formData.employeeName}`
-      );
-
-      // Trigger Webhook Event (Internal simulation)
-      try {
-        await fetch('http://localhost:3001/api/webhooks/test-trigger', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            event: 'payment.completed',
-            payload: {
-              id: newClaim.id,
-              employeeName: newClaim.employeeName,
-              amount: newClaim.amount,
-              status: 'created',
-            },
-          }),
+        const xdr = await buildClaimableBalanceXdr({
+          sourceAddress: address!,
+          claimantPublicKey,
+          amount: String(formData.amount),
+          assetCode: 'USDC',
         });
-      } catch {
-        console.warn('Webhook test-trigger skipped (Backend might not be running)');
-      }
 
-      resetSimulation();
-      setFormData(initialFormState);
+        // The connected wallet signs the real transaction; no client-embedded
+        // secret key is ever involved.
+        await sign(xdr);
+
+        // Simulate a brief delay for network broadcast
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+
+        // Add to pending claims
+        const newClaim: PendingClaim = {
+          id: Math.random().toString(36).substr(2, 9),
+          employeeName: formData.employeeName,
+          amount: formData.amount,
+          dateScheduled: formData.startDate || new Date().toISOString().split('T')[0],
+          claimantPublicKey,
+          status: 'Pending Claim',
+        };
+
+        const updatedClaims = [...pendingClaims, newClaim];
+        setPendingClaims(updatedClaims);
+        localStorage.setItem('pending-claims', JSON.stringify(updatedClaims));
+
+        // Subscribe to updates for this new claim
+        subscribeToTransaction(newClaim.id);
+
+        notifySuccess(
+          'Broadcast successful!',
+          `Claimable balance created for ${formData.employeeName}`
+        );
+
+        // Trigger Webhook Event (Internal simulation)
+        try {
+          await fetch('http://localhost:3001/api/webhooks/test-trigger', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              event: 'payment.completed',
+              payload: {
+                id: newClaim.id,
+                employeeName: newClaim.employeeName,
+                amount: newClaim.amount,
+                status: 'created',
+              },
+            }),
+          });
+        } catch {
+          console.warn('Webhook test-trigger skipped (Backend might not be running)');
+        }
+
+        resetSimulation();
+        setFormData(initialFormState);
+        setRecipientPublicKey(null);
+      });
     } catch (err) {
       console.error(err);
       notifyError('Broadcast failed', 'Please check your network connection and try again.');

--- a/frontend/src/services/stellar.ts
+++ b/frontend/src/services/stellar.ts
@@ -1,4 +1,12 @@
-import { Keypair, Operation, Asset, Claimant } from '@stellar/stellar-sdk';
+import {
+  BASE_FEE,
+  Horizon,
+  Keypair,
+  Operation,
+  Asset,
+  Claimant,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
 
 export interface ClaimableBalanceDetails {
   id: string;
@@ -17,57 +25,68 @@ export const generateWallet = () => {
   };
 };
 
-export const createClaimableBalanceTransaction = (
-  sourceSecretKey: string,
-  claimantPublicKey: string,
-  amount: string,
-  assetCode: string = 'USDC',
-  assetIssuer?: string
-) => {
-  // Mock building the transaction as we don't have the full Stellar infrastructure initialized right now
-  try {
-    // We just parse the secret key to ensure it's valid if possible
-    try {
-      Keypair.fromSecret(sourceSecretKey);
-    } catch {
-      // Fallback for mocked employer secret
-    }
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
 
-    // In a real app, you would load the source account's sequence number from an API like horizon
-    // const account = await server.loadAccount(sourceKeypair.publicKey());
+function getHorizonUrl(): string {
+  const url =
+    (import.meta.env.PUBLIC_STELLAR_HORIZON_URL as string | undefined) || 'http://localhost:8000';
+  return normalizeBaseUrl(url);
+}
 
-    // Instead of actually building a complete hashable tx, let's just return a simulated payload
-    // since we do not have a working horizon server to query sequence numbers.
-    const asset =
-      assetCode === 'XLM'
-        ? Asset.native()
-        : new Asset(assetCode, assetIssuer || Keypair.random().publicKey());
+function getNetworkPassphrase(): string {
+  return (
+    (import.meta.env.PUBLIC_STELLAR_NETWORK_PASSPHRASE as string | undefined) ||
+    'Standalone Network ; February 2017'
+  );
+}
 
-    const operation = Operation.createClaimableBalance({
-      asset: asset,
-      amount: amount,
-      claimants: [
-        new Claimant(
-          claimantPublicKey,
-          Claimant.predicateUnconditional() // Employee can claim whenever they want
-        ),
-      ],
-    });
+export interface BuildClaimableBalanceInput {
+  /** Public key of the employer account funding the payment (the connected wallet). */
+  sourceAddress: string;
+  claimantPublicKey: string;
+  amount: string;
+  assetCode?: string;
+  assetIssuer?: string;
+  horizonUrlOverride?: string;
+}
 
-    console.log('Simulating Claimable Balance Operation:', operation);
+/**
+ * Builds a real, unsigned SEP-0010-independent claimable-balance transaction
+ * XDR for the employer to review (simulate) and sign with their connected
+ * wallet. Loads the employer's live sequence number from Horizon so the XDR
+ * is submittable, not a placeholder.
+ */
+export async function buildClaimableBalanceXdr(input: BuildClaimableBalanceInput): Promise<string> {
+  const horizonUrl = normalizeBaseUrl(input.horizonUrlOverride || getHorizonUrl());
+  const server = new Horizon.Server(horizonUrl, { allowHttp: horizonUrl.startsWith('http://') });
+  const account = await server.loadAccount(input.sourceAddress);
 
-    // Normally we would build this into a transaction, sign it, and submit it to Horizon.
-    return {
-      success: true,
-      simulatedOperation: operation,
-      amount,
-      claimantPublicKey,
-    };
-  } catch (error) {
-    console.error('Error creating claimable balance transaction:', error);
-    return {
-      success: false,
-      error,
-    };
-  }
-};
+  const assetCode = input.assetCode || 'USDC';
+  const asset =
+    assetCode === 'XLM'
+      ? Asset.native()
+      : new Asset(assetCode, input.assetIssuer || input.sourceAddress);
+
+  const transaction = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(
+      Operation.createClaimableBalance({
+        asset,
+        amount: input.amount,
+        claimants: [
+          new Claimant(
+            input.claimantPublicKey,
+            Claimant.predicateUnconditional() // Employee can claim whenever they want
+          ),
+        ],
+      })
+    )
+    .setTimeout(180)
+    .build();
+
+  return transaction.toXDR();
+}


### PR DESCRIPTION
## Summary

Closes #388.

Removes `MOCK_EMPLOYER_SECRET` (a Stellar secret-key-shaped constant hardcoded in `PayrollScheduler.tsx`) and the mock-signing path, routing payroll scheduling through the real wallet-signing flow.

## Changes

- **`services/stellar.ts`**: replaces `createClaimableBalanceTransaction` (took a secret key, never actually built a hashable transaction — just returned a simulated operation object) with **`buildClaimableBalanceXdr`**, which loads the employer's live account from **Horizon** and builds a real, submittable claimable-balance transaction, mirroring the existing `TransactionBuilder`/Horizon pattern already used in `services/crossAssetPayment.ts`.
- **`PayrollScheduler.tsx`**:
  - `handleInitialize` now builds **real transaction XDR** from the connected employer wallet's address and feeds it into the existing simulation panel — no more hardcoded base64 stub.
  - `handleBroadcast` signs that same real XDR through **`useWalletSigning()`** (backed by `WalletProvider` / `@creit.tech/stellar-wallets-kit`), guarded by `requireWallet()` so it prompts a wallet connection if needed.
  - The employee claimant key is generated once per schedule and reused across simulate + broadcast so they refer to the same transaction.

## Acceptance criteria

- [x] No secret-key-shaped constants or hardcoded secrets remain in `PayrollScheduler.tsx` or elsewhere in `frontend/src`.
- [x] Scheduling a payroll uses the connected wallet to sign; no client-embedded key is involved.
- [x] Transaction simulation runs against real transaction XDR.
- [x] `npm run lint` and the type build pass.

## Verification

- `npm run lint` — clean.
- `npx prettier . --check` — clean.
- `npm run build` (`tsc -b && vite build`) — succeeds.
- `npm test --if-present` — no test script defined for this package (pre-existing); no regressions to existing e2e coverage, which does not exercise this initialize/broadcast flow.