### PR TITLE
feat(backend): add CSP violation reporting endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import { syncTenantFromUser } from './middleware/tenantContext.js';
 import v1Routes from './routes/v1/index.js';
 import authRoutes from './routes/authRoutes.js';
 import webhookRoutes from './routes/webhook.routes.js';
+import cspReportRoutes from './routes/cspReport.routes.js';
 
 // Upstream Routes
 import payrollRoutes from './routes/payroll.routes.js';
@@ -65,6 +66,7 @@ app.use(
       directives: {
         defaultSrc: ["'none'"],
         frameAncestors: ["'none'"],
+        reportUri: ['/api/csp-report'],
       },
     },
     hsts: {
@@ -87,6 +89,12 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(passport.initialize());
+
+// CSP violation reports — mounted ahead of the audit/rate-limit/tenant
+// middleware below so unauthenticated browser reports (per spec, sent by the
+// browser itself, never a logged-in client) aren't blocked or throttled by
+// tenant- or org-aware middleware that assumes an authenticated caller.
+app.use('/api/csp-report', cspReportRoutes);
 
 // Global audit logging — records every API request with sanitization
 app.use(

--- a/backend/src/routes/__tests__/cspReport.routes.test.ts
+++ b/backend/src/routes/__tests__/cspReport.routes.test.ts
@@ -1,0 +1,136 @@
+import request from 'supertest';
+import express from 'express';
+import cspReportRoutes from '../cspReport.routes.js';
+import logger from '../../utils/logger.js';
+
+const app = express();
+app.use('/api/csp-report', cspReportRoutes);
+
+describe('CSP report routes', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('accepts a classic application/csp-report envelope without authentication', async () => {
+    const res = await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(
+        JSON.stringify({
+          'csp-report': {
+            'document-uri': 'https://payd.example/payroll',
+            'violated-directive': 'script-src',
+            'blocked-uri': 'https://evil.example/x.js',
+            'source-file': 'https://payd.example/bundle.js',
+            'line-number': 42,
+          },
+        })
+      );
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'CSP violation reported',
+      expect.objectContaining({
+        documentUri: 'https://payd.example/payroll',
+        violatedDirective: 'script-src',
+        blockedUri: 'https://evil.example/x.js',
+        sourceFile: 'https://payd.example/bundle.js',
+        lineNumber: 42,
+      })
+    );
+  });
+
+  it('accepts application/json content type too', async () => {
+    const res = await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/json')
+      .send({
+        'csp-report': {
+          'document-uri': 'https://payd.example/',
+          'violated-directive': 'style-src',
+          'blocked-uri': 'inline',
+        },
+      });
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles a malformed report body without crashing the process', async () => {
+    const res = await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send('not json at all {{{');
+
+    // The body-parser rejects unparsable JSON with a 400 (standard, not a
+    // crash); a report with a recognizable shape but missing/odd fields is
+    // still recorded gracefully (see the empty-object case below).
+    expect(res.status).toBe(400);
+  });
+
+  it('records a report with an unrecognized shape using placeholder fields, without crashing', async () => {
+    const res = await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(JSON.stringify({ unexpected: 'shape' }));
+
+    expect(res.status).toBe(204);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'CSP violation reported',
+      expect.objectContaining({ documentUri: 'unknown', violatedDirective: 'unknown' })
+    );
+  });
+
+  it('deduplicates identical directive+blocked-uri reports within the window', async () => {
+    const report = {
+      'csp-report': {
+        'document-uri': 'https://payd.example/',
+        'violated-directive': 'img-src',
+        'blocked-uri': 'https://tracker.example/pixel.gif',
+      },
+    };
+
+    await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(JSON.stringify(report));
+    await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(JSON.stringify(report));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('lists recently recorded violations for review', async () => {
+    await request(app)
+      .post('/api/csp-report')
+      .set('Content-Type', 'application/csp-report')
+      .send(
+        JSON.stringify({
+          'csp-report': {
+            'document-uri': 'https://payd.example/list-me',
+            'violated-directive': 'connect-src',
+            'blocked-uri': 'https://other.example/api',
+          },
+        })
+      );
+
+    const res = await request(app).get('/api/csp-report');
+    expect(res.status).toBe(200);
+    expect(res.body.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ documentUri: 'https://payd.example/list-me' }),
+      ])
+    );
+  });
+});

--- a/backend/src/routes/cspReport.routes.ts
+++ b/backend/src/routes/cspReport.routes.ts
@@ -1,0 +1,34 @@
+import express, { Router, Request, Response } from 'express';
+import logger from '../utils/logger.js';
+import { recordCspViolation, getRecentCspViolations } from '../services/cspReport.service.js';
+
+const router = Router();
+
+// Browsers send the classic report as `application/csp-report`; some send
+// `application/json`; the newer Reporting API sends `application/reports+json`.
+// None of these match express.json()'s default `application/json`-only type,
+// so a dedicated parser is scoped to this route.
+const cspReportBodyParser = express.json({
+  type: ['application/csp-report', 'application/json', 'application/reports+json'],
+});
+
+// POST /api/csp-report — accepts violation reports with no authentication
+// (per spec, the browser sends these, not an authenticated client).
+router.post('/', cspReportBodyParser, (req: Request, res: Response) => {
+  try {
+    recordCspViolation(req.body);
+  } catch (err) {
+    // Never let a malformed report crash the handler.
+    logger.error('Failed to process CSP violation report', err);
+  }
+  // Browsers ignore the response body for reports; 204 is the conventional ack.
+  res.status(204).end();
+});
+
+// GET /api/csp-report — basic log-aggregation view for reviewing recent violations.
+router.get('/', (req: Request, res: Response) => {
+  const limit = Math.min(Number(req.query.limit) || 100, 500);
+  res.json({ violations: getRecentCspViolations(limit) });
+});
+
+export default router;

--- a/backend/src/services/cspReport.service.ts
+++ b/backend/src/services/cspReport.service.ts
@@ -1,0 +1,98 @@
+import logger from '../utils/logger.js';
+
+export interface CspViolation {
+  documentUri: string;
+  violatedDirective: string;
+  blockedUri: string;
+  sourceFile: string;
+  lineNumber: number;
+  receivedAt: string;
+}
+
+const DEDUPE_WINDOW_MS = 5 * 60 * 1000;
+const MAX_STORED_VIOLATIONS = 500;
+
+// In-memory structured store for the violations dashboard/log-aggregation
+// endpoint. A single process-local ring buffer is sufficient for the scope of
+// this issue (out of scope: real-time alerting, third-party report services).
+const violations: CspViolation[] = [];
+
+// directive|blockedUri -> last-seen timestamp (ms), for de-duplication.
+const lastSeenByFingerprint = new Map<string, number>();
+
+function fingerprint(violatedDirective: string, blockedUri: string): string {
+  return `${violatedDirective}|${blockedUri}`;
+}
+
+/** True if an identical (directive, blocked-uri) pair was recorded within the last 5 minutes. */
+function isDuplicate(violatedDirective: string, blockedUri: string, now: number): boolean {
+  const key = fingerprint(violatedDirective, blockedUri);
+  const lastSeen = lastSeenByFingerprint.get(key);
+  return lastSeen !== undefined && now - lastSeen < DEDUPE_WINDOW_MS;
+}
+
+/**
+ * Records a CSP violation report: logs it with full context and stores it in
+ * the queryable in-memory buffer, unless it duplicates a (directive,
+ * blocked-uri) pair already seen within the last 5 minutes.
+ *
+ * Never throws — malformed/partial reports are logged and recorded with
+ * whatever fields are present rather than crashing the request handler.
+ */
+export function recordCspViolation(rawReport: unknown): { deduped: boolean } {
+  const report = extractReport(rawReport);
+  const now = Date.now();
+
+  if (isDuplicate(report.violatedDirective, report.blockedUri, now)) {
+    return { deduped: true };
+  }
+
+  lastSeenByFingerprint.set(fingerprint(report.violatedDirective, report.blockedUri), now);
+
+  const violation: CspViolation = { ...report, receivedAt: new Date(now).toISOString() };
+  violations.push(violation);
+  if (violations.length > MAX_STORED_VIOLATIONS) {
+    violations.shift();
+  }
+
+  logger.warn('CSP violation reported', violation);
+  return { deduped: false };
+}
+
+/** Returns the most recent stored violations, newest first — backs the review/dashboard endpoint. */
+export function getRecentCspViolations(limit = 100): CspViolation[] {
+  return violations.slice(-limit).reverse();
+}
+
+function extractReport(rawReport: unknown): Omit<CspViolation, 'receivedAt'> {
+  // Browsers POST either the classic `{"csp-report": {...}}` envelope or,
+  // under the newer Reporting API, an array of `{type: "csp-violation", body: {...}}`.
+  const body: any =
+    rawReport && typeof rawReport === 'object' && 'csp-report' in (rawReport as any)
+      ? (rawReport as any)['csp-report']
+      : Array.isArray(rawReport) && rawReport[0]?.body
+        ? rawReport[0].body
+        : (rawReport ?? {});
+
+  return {
+    documentUri: stringField(body, ['document-uri', 'documentURL']),
+    violatedDirective: stringField(body, ['violated-directive', 'effectiveDirective']),
+    blockedUri: stringField(body, ['blocked-uri', 'blockedURL']),
+    sourceFile: stringField(body, ['source-file', 'sourceFile']),
+    lineNumber: numberField(body, ['line-number', 'lineNumber']),
+  };
+}
+
+function stringField(body: any, keys: string[]): string {
+  for (const key of keys) {
+    if (typeof body?.[key] === 'string') return body[key];
+  }
+  return 'unknown';
+}
+
+function numberField(body: any, keys: string[]): number {
+  for (const key of keys) {
+    if (typeof body?.[key] === 'number') return body[key];
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary

Closes #425.

Adds `POST /api/csp-report` so browser-reported Content-Security-Policy violations are captured instead of going unmonitored, and points Helmet's CSP `report-uri` at it.

## Changes

- **`services/cspReport.service.ts`**: parses both the classic `{"csp-report": {...}}` envelope and the newer Reporting API array shape; logs each violation with full context (document-uri, violated-directive, blocked-uri, source-file, line-number) via the existing structured logger; de-duplicates identical (directive, blocked-uri) pairs within a 5-minute window. Malformed/partial reports never throw.
- **`routes/cspReport.routes.ts`**: `POST /` accepts `application/csp-report`, `application/json`, and `application/reports+json`; requires no authentication; always acks `204`. `GET /` returns recent violations — a basic review/dashboard surface backed by an in-memory ring buffer (500 entries), rather than a new DB migration, to keep this scoped.
- **`app.ts`**: mounts the route ahead of the `/api`-scoped audit/rate-limit/tenant middleware so unauthenticated browser reports aren't blocked or throttled by middleware that assumes an authenticated caller. Adds `reportUri: ['/api/csp-report']` to the existing Helmet CSP directives.

## Acceptance criteria

- [x] `POST /api/csp-report` accepts CSP violation reports without authentication
- [x] Violations are logged with full context (directive, blocked URI, source, line)
- [x] Helmet CSP config includes `report-uri` pointing to the new endpoint
- [x] Duplicate violations are deduplicated (same directive + blocked-uri within 5 minutes)
- [x] Violations are stored in a queryable format (structured log + in-memory queryable buffer via `GET /api/csp-report`)
- [x] Endpoint handles malformed reports gracefully (no crashes)

## Verification

- New test suite `routes/__tests__/cspReport.routes.test.ts` — 6/6 passing (classic envelope, `application/json` content type, malformed body, unrecognized shape, dedup, listing).
- `npx tsc --noEmit` on the new files — clean. (Note: `npm run build`/`npm run lint` for the whole backend package are currently broken on `main` by pre-existing, unrelated issues — a syntax error in `tenantConfigService.ts` and an `.eslintrc.js`/ESM config conflict — confirmed present before this change and out of scope here. There is no backend CI workflow in this repo today; `.github/workflows/` only covers frontend/contracts.)